### PR TITLE
Enablers for Saluki I2C and SPI

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_clockconfig.c
+++ b/arch/risc-v/src/mpfs/mpfs_clockconfig.c
@@ -386,6 +386,7 @@ void mpfs_clockconfig(void)
                                   SUBBLK_CLOCK_CR_MMUART2_MASK |
                                   SUBBLK_CLOCK_CR_MMUART3_MASK |
                                   SUBBLK_CLOCK_CR_MMUART4_MASK |
+                                  SUBBLK_CLOCK_CR_I2C0_MASK |
                                   SUBBLK_CLOCK_CR_I2C1_MASK |
                                   SUBBLK_CLOCK_CR_CFM_MASK);
 
@@ -399,6 +400,7 @@ void mpfs_clockconfig(void)
                                  SOFT_RESET_CR_MMUART2_MASK |
                                  SOFT_RESET_CR_MMUART3_MASK |
                                  SOFT_RESET_CR_MMUART4_MASK |
+                                 SOFT_RESET_CR_I2C0_MASK |
                                  SOFT_RESET_CR_I2C1_MASK |
                                  SOFT_RESET_CR_CFM_MASK);
 

--- a/arch/risc-v/src/mpfs/mpfs_spi.c
+++ b/arch/risc-v/src/mpfs/mpfs_spi.c
@@ -147,8 +147,10 @@ struct mpfs_spi_priv_s
 
 static int mpfs_spi_lock(struct spi_dev_s *dev, bool lock);
 
+/* TODO: add some configuration option to enable this
 static void mpfs_spi_select(struct spi_dev_s *dev, uint32_t devid,
                             bool selected);
+*/
 
 static uint32_t mpfs_spi_setfrequency(struct spi_dev_s *dev,
                                       uint32_t frequency);
@@ -188,10 +190,11 @@ static const struct mpfs_spi_config_s mpfs_spi_config =
     .use_irq  = true,
 };
 
-static const struct spi_ops_s mpfs_spi_ops =
+#ifdef CONFIG_MPFS_SPI0
+static const struct spi_ops_s mpfs_spi0_ops =
 {
     .lock             = mpfs_spi_lock,
-    .select           = mpfs_spi_select,
+    .select           = mpfs_spi0_select,
     .setfrequency     = mpfs_spi_setfrequency,
 #ifdef CONFIG_SPI_CS_DELAY_CONTROL
     .setdelay         = mpfs_spi_setdelay,
@@ -218,12 +221,12 @@ static const struct spi_ops_s mpfs_spi_ops =
     .registercallback = NULL,
 };
 
-#ifdef CONFIG_MPFS_SPI0
+
 static struct mpfs_spi_priv_s g_mpfs_spi0_priv =
 {
   .spi_dev =
               {
-                .ops = &mpfs_spi_ops
+                .ops = &mpfs_spi0_ops
               },
   .config            = &mpfs_spi_config,
   .hw_base           = MPFS_SPI0_LO_BASE,
@@ -232,12 +235,42 @@ static struct mpfs_spi_priv_s g_mpfs_spi0_priv =
   .devid             = 0
 };
 #endif /* CONFIG_MPFS_SPI0 */
+
 #ifdef CONFIG_MPFS_SPI1
+static const struct spi_ops_s mpfs_spi1_ops =
+{
+    .lock             = mpfs_spi_lock,
+    .select           = mpfs_spi1_select,
+    .setfrequency     = mpfs_spi_setfrequency,
+#ifdef CONFIG_SPI_CS_DELAY_CONTROL
+    .setdelay         = mpfs_spi_setdelay,
+#endif
+    .setmode          = mpfs_spi_setmode,
+    .setbits          = mpfs_spi_setbits,
+#ifdef CONFIG_SPI_HWFEATURES
+    .hwfeatures       = mpfs_spi_hwfeatures,
+#endif
+    .status           = mpfs_spi_status,
+#ifdef CONFIG_SPI_CMDDATA
+    .cmddata          = mpfs_spi_cmddata,
+#endif
+    .send             = mpfs_spi_send,
+#ifdef CONFIG_SPI_EXCHANGE
+    .exchange         = mpfs_spi_exchange,
+#else
+    .sndblock         = mpfs_spi_sndblock,
+    .recvblock        = mpfs_spi_recvblock,
+#endif
+#ifdef CONFIG_SPI_TRIGGER
+    .trigger          = mpfs_spi_trigger,
+#endif
+    .registercallback = NULL,
+};
 static struct mpfs_spi_priv_s g_mpfs_spi1_priv =
 {
   .spi_dev =
               {
-                .ops = &mpfs_spi_ops
+                .ops = &mpfs_spi1_ops
               },
   .config            = &mpfs_spi_config,
   .hw_base           = MPFS_SPI1_LO_BASE,
@@ -355,6 +388,9 @@ static int mpfs_spi_lock(struct spi_dev_s *dev, bool lock)
  *
  ****************************************************************************/
 
+
+/* TODO: add some configuration option to enable this
+
 static void mpfs_spi_select(struct spi_dev_s *dev, uint32_t devid,
                             bool selected)
 {
@@ -373,6 +409,7 @@ static void mpfs_spi_select(struct spi_dev_s *dev, uint32_t devid,
 
   spiinfo("devid: %u, CS: %s\n", devid, selected ? "select" : "free");
 }
+*/
 
 /****************************************************************************
  * Name: mpfs_spi_setfrequency
@@ -1429,10 +1466,10 @@ static void mpfs_spi_deinit(struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-struct spi_dev_s *mpfs_spibus_initialize(int port)
+FAR struct spi_dev_s *mpfs_spibus_initialize(int port)
 {
   struct spi_dev_s *spi_dev;
-  struct mpfs_spi_priv_s *priv;
+  FAR struct mpfs_spi_priv_s *priv = NULL;
   irqstate_t flags;
   int ret;
 

--- a/arch/risc-v/src/mpfs/mpfs_spi.h
+++ b/arch/risc-v/src/mpfs/mpfs_spi.h
@@ -75,6 +75,28 @@ struct spi_dev_s *mpfs_spibus_initialize(int port);
 
 int mpfs_spibus_uninitialize(FAR struct spi_dev_s *dev);
 
+/****************************************************************************
+ * Name:  mpfs_spi0/1/..._select
+ *
+ * Description:
+ *   The external function, mpfs_spi0/1/..._select,
+ *   must be provided by board-specific logic.  This is implementation of the
+ *   select of the SPI interface defined by
+ *   struct spi_ops_s (see include/nuttx/spi/spi.h).
+ *   All other methods (including mpfs_spibus_initialize())
+ *   are provided by common MPFS logic.
+ ****************************************************************************/
+
+#ifdef CONFIG_MPFS_SPI0
+void mpfs_spi0_select(FAR struct spi_dev_s *dev,
+                        uint32_t devid, bool selected);
+#endif
+
+#ifdef CONFIG_MPFS_SPI1
+void mpfs_spi1_select(FAR struct spi_dev_s *dev,
+                        uint32_t devid, bool selected);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Enable I2C0 in clockconfig and add support for board-specific SPI select logic 