### PR TITLE
Fix PROTECTED_BUILD build errors for mpfs target

### DIFF
--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -59,8 +59,10 @@ CHIP_CSRCS  += mpfs_dma.c
 endif
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS  += riscv_task_start.c riscv_pthread_start.c
-CMN_CSRCS  += riscv_signal_dispatch.c riscv_pmp.c
+CMN_CSRCS  += riscv_task_start.c
+CMN_CSRCS  += riscv_pthread_start.c riscv_pthread_exit.c
+CMN_CSRCS  += riscv_signal_dispatch.c
+CMN_CSRCS  += riscv_pmp.c
 CMN_UASRCS += riscv_signal_handler.S
 
 CHIP_CSRCS += mpfs_userspace.c

--- a/boards/risc-v/mpfs/common/kernel/mpfs_userspace.c
+++ b/boards/risc-v/mpfs/common/kernel/mpfs_userspace.c
@@ -99,9 +99,6 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* Task/thread startup routines */
 
   .task_startup     = nxtask_startup,
-#ifndef CONFIG_DISABLE_PTHREAD
-  .pthread_startup  = pthread_startup,
-#endif
 
   /* Signal handler trampoline */
 


### PR DESCRIPTION
Userspace struct definition did not have pthread_startup
The definition for up_pthread_exit was not compiled ever
