### PR TITLE
drivers/eeprom/i2c_xx24xx.c: Fix compiler warnings

### DIFF
--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -502,7 +502,7 @@ static off_t ee24xx_seek(FAR struct file *filep, off_t offset, int whence)
     {
       filep->f_pos = newpos;
       ret = newpos;
-      finfo("SEEK newpos %d\n", newpos);
+      finfo("SEEK newpos %ld\n", (long)newpos);
     }
   else
     {
@@ -553,7 +553,7 @@ static ssize_t ee24xx_read(FAR struct file *filep, FAR char *buffer,
 
   /* Write data address */
 
-  finfo("READ %d bytes at pos %d\n", len, filep->f_pos);
+  finfo("READ %ld bytes at pos %ld\n", (long)len, (long)filep->f_pos);
 
   addr_hi           = (filep->f_pos >> (eedev->addrlen << 3));
 
@@ -697,14 +697,14 @@ static ssize_t ee24xx_write(FAR struct file *filep, FAR const char *buffer,
       return -EFBIG;
     }
 
-  finfo("Entering with len=%d\n", len);
+  finfo("Entering with len=%ld\n", (long)len);
 
   /* Clamp len to avoid crossing the end of the memory */
 
   if ((len + filep->f_pos) > eedev->size)
     {
       len = eedev->size - filep->f_pos;
-      finfo("Len clamped to %d\n", len);
+      finfo("Len clamped to %ld\n", (long)len);
     }
 
   savelen = len; /* save number of bytes written */
@@ -733,8 +733,8 @@ static ssize_t ee24xx_write(FAR struct file *filep, FAR const char *buffer,
 
   if (pageoff > 0)
     {
-      finfo("First %d unaligned bytes at %d (pageoff %d)\n",
-            cnt, filep->f_pos, pageoff);
+      finfo("First %ld unaligned bytes at %ld (pageoff %d)\n",
+            (long)cnt, (long)filep->f_pos, pageoff);
 
       ret = ee24xx_writepage(eedev, filep->f_pos, buffer, cnt);
       if (ret < 0)
@@ -765,7 +765,8 @@ static ssize_t ee24xx_write(FAR struct file *filep, FAR const char *buffer,
           cnt = eedev->pgsize;
         }
 
-      finfo("Aligned page write for %d bytes at %d\n", cnt, filep->f_pos);
+      finfo("Aligned page write for %ld bytes at %ld\n",
+            (long)cnt, (long)filep->f_pos);
 
       ret = ee24xx_writepage(eedev, filep->f_pos, buffer, cnt);
       if (ret < 0)


### PR DESCRIPTION
Debug prints were not able to handle 64bit off_t and size_t.

## Summary

## Impact

## Testing

