### PR TITLE
Prepare riscv / rv64 for CONFIG_BUILD_KERNEL

### DIFF
--- a/arch/risc-v/include/rv64gc/irq.h
+++ b/arch/risc-v/include/rv64gc/irq.h
@@ -406,7 +406,7 @@
 struct xcpt_syscall_s
 {
   uint64_t sysreturn;   /* The return PC */
-#ifdef CONFIG_BUILD_PROTECTED
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
   uint64_t int_ctx;     /* Interrupt context (i.e. mstatus) */
 #endif
 };
@@ -436,7 +436,7 @@ struct xcptcontext
   uint64_t saved_epc;     /* Trampoline PC */
   uint64_t saved_int_ctx; /* Interrupt context with interrupts disabled. */
 
-#ifdef CONFIG_BUILD_PROTECTED
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
   /* This is the saved address to use when returning from a user-space
    * signal handler.
    */

--- a/arch/risc-v/include/rv64gc/syscall.h
+++ b/arch/risc-v/include/rv64gc/syscall.h
@@ -53,20 +53,6 @@
 
 /* Configuration ************************************************************/
 
-/* SYS call 1 and 2 are defined for internal use by the RISC-V port (see
- * arch/risc-v/include/rv64gc/syscall.h). In addition, SYS call 3 is the
- * return from a SYS call in kernel mode. The first four syscall values must,
- * therefore, be reserved (0 is not used).
- */
-
-#ifdef CONFIG_BUILD_KERNEL
-#  ifndef CONFIG_SYS_RESERVED
-#    error "CONFIG_SYS_RESERVED must be defined to the value 4"
-#  elif CONFIG_SYS_RESERVED != 4
-#    error "CONFIG_SYS_RESERVED must have the value 4"
-#  endif
-#endif
-
 /* sys_call macros **********************************************************/
 
 #ifndef __ASSEMBLY__

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -58,14 +58,24 @@ ifeq ($(CONFIG_MPFS_DMA),y)
 CHIP_CSRCS  += mpfs_dma.c
 endif
 
+# Flag to enable certain modules for non-flat builds (PROTECTED/KERNEL)
+__MPFS_BUILD_NONFLAT =
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
+CHIP_CSRCS += mpfs_userspace.c
+__MPFS_BUILD_NONFLAT=y
+endif
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+__MPFS_BUILD_NONFLAT=y
+endif
+
+ifeq ($(__MPFS_BUILD_NONFLAT),y)
 CMN_CSRCS  += riscv_task_start.c
 CMN_CSRCS  += riscv_pthread_start.c riscv_pthread_exit.c
 CMN_CSRCS  += riscv_signal_dispatch.c
 
 CMN_UASRCS += riscv_signal_handler.S
-
-CHIP_CSRCS += mpfs_userspace.c
 endif
 
 ifeq ($(CONFIG_ARCH_USE_MPU),y)

--- a/arch/risc-v/src/mpfs/mpfs_allocateheap.c
+++ b/arch/risc-v/src/mpfs/mpfs_allocateheap.c
@@ -75,7 +75,7 @@
  *   Kernel heap               Size determined by CONFIG_MM_KERNEL_HEAPSIZE
  *
  ****************************************************************************/
-
+#if !defined(CONFIG_BUILD_KERNEL)
 void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
@@ -100,8 +100,9 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
   *heap_start = (void *)g_idle_topstack;
   *heap_size = KRAM_END - g_idle_topstack;
-#endif
+#endif /* CONFIG_BUILD_PROTECTED && CONFIG_MM_KERNEL_HEAP */
 }
+#endif /* CONFIG_BUILD_KERNEL */
 
 /****************************************************************************
  * Name: up_allocate_kheap
@@ -113,7 +114,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
+#if !defined(CONFIG_BUILD_FLAT) && defined(CONFIG_MM_KERNEL_HEAP)
 void up_allocate_kheap(void **heap_start, size_t *heap_size)
 {
   /* Return the kernel heap settings. */
@@ -121,7 +122,7 @@ void up_allocate_kheap(void **heap_start, size_t *heap_size)
   *heap_start = (void *)g_idle_topstack;
   *heap_size = KRAM_END - g_idle_topstack;
 }
-#endif
+#endif /* !CONFIG_BUILD_FLAT && CONFIG_MM_KERNEL_HEAP */
 
 /****************************************************************************
  * Name: up_addregion

--- a/arch/risc-v/src/rv64gc/riscv_swint.c
+++ b/arch/risc-v/src/rv64gc/riscv_swint.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 
 #include <arch/irq.h>
+#include <nuttx/addrenv.h>
 #include <nuttx/sched.h>
 #include <nuttx/userspace.h>
 
@@ -227,19 +228,19 @@ int riscv_swint(int irq, void *context, void *arg)
            */
 
           regs[REG_EPC]         = rtcb->xcp.syscall[index].sysreturn;
-#ifdef CONFIG_BUILD_PROTECTED
-          regs[REG_INT_CTX]      = rtcb->xcp.syscall[index].int_ctx;
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
+          regs[REG_INT_CTX]     = rtcb->xcp.syscall[index].int_ctx;
 #endif
 
           /* The return value must be in A0-A1.
            * dispatch_syscall() temporarily moved the value for R0 into A2.
            */
 
-          regs[REG_A0]         = regs[REG_A2];
+          regs[REG_A0]          = regs[REG_A2];
 
           /* Save the new SYSCALL nesting level */
 
-          rtcb->xcp.nsyscalls  = index;
+          rtcb->xcp.nsyscalls   = index;
 
           /* Handle any signal actions that were deferred while processing
            * the system call.
@@ -264,19 +265,27 @@ int riscv_swint(int irq, void *context, void *arg)
        *   A3 = argv
        */
 
-#ifdef CONFIG_BUILD_PROTECTED
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
       case SYS_task_start:
         {
           /* Set up to return to the user-space task start-up function in
            * unprivileged mode.
            */
 
-          regs[REG_EPC]      = (uintptr_t)USERSPACE->task_startup & ~1;
+#if defined (CONFIG_BUILD_PROTECTED)
+          /* Use the nxtask_startup trampoline function */
 
+          regs[REG_EPC]      = (uintptr_t)USERSPACE->task_startup & ~1;
           regs[REG_A0]       = regs[REG_A1]; /* Task entry */
           regs[REG_A1]       = regs[REG_A2]; /* argc */
           regs[REG_A2]       = regs[REG_A3]; /* argv */
+#else
+          /* Start the user task directly */
 
+          regs[REG_EPC]      = (uintptr_t)regs[REG_A1] & ~1;
+          regs[REG_A0]       = regs[REG_A2]; /* argc */
+          regs[REG_A1]       = regs[REG_A3]; /* argv */
+#endif
           regs[REG_INT_CTX] &= ~MSTATUS_MPPM; /* User mode */
         }
         break;
@@ -359,7 +368,7 @@ int riscv_swint(int irq, void *context, void *arg)
        *   R4 = ucontext
        */
 
-#ifdef CONFIG_BUILD_PROTECTED
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
       case SYS_signal_handler:
         {
           struct tcb_s *rtcb   = nxsched_self();
@@ -372,18 +381,21 @@ int riscv_swint(int irq, void *context, void *arg)
           /* Set up to return to the user-space trampoline function in
            * unprivileged mode.
            */
-
-          regs[REG_EPC]      = (uintptr_t)USERSPACE->signal_handler & ~1;
-          regs[REG_INT_CTX] &= ~MSTATUS_MPPM; /* User mode */
+#if defined (CONFIG_BUILD_PROTECTED)
+          regs[REG_EPC]        = (uintptr_t)USERSPACE->signal_handler & ~1;
+#else
+          regs[REG_EPC]        = (uintptr_t)ARCH_DATA_RESERVE->ar_sigtramp;
+#endif
+          regs[REG_INT_CTX]   &= ~MSTATUS_MPPM; /* User mode */
 
           /* Change the parameter ordering to match the expectation of struct
            * userpace_s signal_handler.
            */
 
-          regs[REG_A0]       = regs[REG_A1]; /* sighand */
-          regs[REG_A1]       = regs[REG_A2]; /* signal */
-          regs[REG_A2]       = regs[REG_A3]; /* info */
-          regs[REG_A3]       = regs[REG_A4]; /* ucontext */
+          regs[REG_A0]         = regs[REG_A1]; /* sighand */
+          regs[REG_A1]         = regs[REG_A2]; /* signal */
+          regs[REG_A2]         = regs[REG_A3]; /* info */
+          regs[REG_A3]         = regs[REG_A4]; /* ucontext */
         }
         break;
 #endif
@@ -397,7 +409,7 @@ int riscv_swint(int irq, void *context, void *arg)
        *   R0 = SYS_signal_handler_return
        */
 
-#ifdef CONFIG_BUILD_PROTECTED
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
       case SYS_signal_handler_return:
         {
           struct tcb_s *rtcb   = nxsched_self();
@@ -437,15 +449,15 @@ int riscv_swint(int irq, void *context, void *arg)
           /* Setup to return to dispatch_syscall in privileged mode. */
 
           rtcb->xcp.syscall[index].sysreturn  = regs[REG_EPC];
-#ifdef CONFIG_BUILD_PROTECTED
-          rtcb->xcp.syscall[index].int_ctx     = regs[REG_INT_CTX];
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
+          rtcb->xcp.syscall[index].int_ctx    = regs[REG_INT_CTX];
 #endif
 
           rtcb->xcp.nsyscalls  = index + 1;
 
           regs[REG_EPC]        = (uintptr_t)dispatch_syscall & ~1;
 
-#ifdef CONFIG_BUILD_PROTECTED
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
           regs[REG_INT_CTX]   |= MSTATUS_MPPM; /* Machine mode */
 #endif
 

--- a/arch/risc-v/src/rv64gc/svcall.h
+++ b/arch/risc-v/src/rv64gc/svcall.h
@@ -44,7 +44,7 @@
  */
 
 #ifdef CONFIG_LIB_SYSCALL
-#  ifdef CONFIG_BUILD_PROTECTED
+#  if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
 #    ifndef CONFIG_SYS_RESERVED
 #      error "CONFIG_SYS_RESERVED must be defined to have the value 9"
 #    elif CONFIG_SYS_RESERVED != 9
@@ -91,7 +91,7 @@
 
 #define SYS_syscall_return        (3)
 
-#ifdef CONFIG_BUILD_PROTECTED
+#if defined (CONFIG_BUILD_PROTECTED) || defined (CONFIG_BUILD_KERNEL)
 /* SYS call 4:
  *
  * void up_task_start(main_t taskentry, int argc, char *argv[])

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -186,7 +186,7 @@ int exec_module(FAR const struct binary_s *binp,
       goto errout_with_addrenv;
     }
 
-#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_ARCH_KERNEL_STACK)
   /* Allocate the kernel stack */
 
   ret = up_addrenv_kstackalloc(&tcb->cmn);

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -39,6 +39,7 @@
 #include <nuttx/mm/mm.h>
 #include <nuttx/mm/shm.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/pgalloc.h>
 #include <nuttx/sched_note.h>
 #include <nuttx/syslog/syslog.h>
 #include <nuttx/binfmt/binfmt.h>


### PR DESCRIPTION
Setup the correct amount of call gates and the parameters passed there
for kernel build. As far as I know, the same call gates are needed
for protected / kernel builds.

When enabling / testing the kernel build, revisit the riscv_swint
file and ensure the ABI is met. Testing the call gates is not possible
right now.

## Summary

## Impact

## Testing

