### PR TITLE
MPFS: Context aware access to mhartid

### DIFF
--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -57,6 +57,8 @@ CHIP_CSRCS += mpfs_idle.c mpfs_irq.c mpfs_irq_dispatch.c
 CHIP_CSRCS += mpfs_lowputc.c mpfs_serial.c
 CHIP_CSRCS += mpfs_start.c mpfs_timerisr.c
 CHIP_CSRCS += mpfs_gpio.c mpfs_systemreset.c
+CHIP_CSRCS += mpfs_mreg.c
+CHIP_CSRCS += mpfs_scratch.c
 
 ifeq ($(CONFIG_MPFS_DMA),y)
 CHIP_CSRCS  += mpfs_dma.c

--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -103,6 +103,10 @@ __start_mpfs:
   csrr a0, mhartid
   beqz a0, .skip_e51
 
+  /* Clear sscratch if u54 */
+
+  csrw sscratch, zero
+
   /* Init delegation registers, mideleg, medeleg, if a U54
    * These are not initialised by the hardware and come up in a random state
    */

--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -39,6 +39,8 @@
 #include "hardware/mpfs_memorymap.h"
 #include "hardware/mpfs_plic.h"
 
+#include "mpfs_mreg.h"
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -78,7 +80,7 @@ void *mpfs_dispatch_irq(uint64_t vector, uint64_t *regs)
 
   /* Firstly, check if the irq is machine external interrupt */
 
-  uint64_t hart_id = READ_CSR(mhartid);
+  uint64_t hart_id = mpfs_mreg_hartid();
   uintptr_t claim_address;
 
   if (hart_id == 0)

--- a/arch/risc-v/src/mpfs/mpfs_mreg.c
+++ b/arch/risc-v/src/mpfs/mpfs_mreg.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_mreg.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <nuttx/arch.h>
+
+#include "mpfs_scratch.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mpfs_mreg_hartid
+ *
+ * Description:
+ *   Context aware way to query hart id
+ *
+ * Returned Value:
+ *   Hart id
+ *
+ ****************************************************************************/
+
+uint64_t mpfs_mreg_hartid(void)
+{
+#ifdef CONFIG_BUILD_KERNEL
+  /* Kernel is in S-mode */
+
+  uint64_t sscratch = mpfs_get_hart_sscratch();
+
+  DEBUGASSERT(sscratch != 0);
+
+  return mpfs_scratch_get_hartid(sscratch);
+#else
+  /* Kernel is in M-mode */
+
+  return READ_CSR(mhartid);
+#endif
+}

--- a/arch/risc-v/src/mpfs/mpfs_mreg.h
+++ b/arch/risc-v/src/mpfs/mpfs_mreg.h
@@ -1,0 +1,43 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_mreg.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISC_V_SRC_MPFS_MPFS_MREG_H_
+#define __ARCH_RISC_V_SRC_MPFS_MPFS_MREG_H_
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Name: mpfs_mreg_hartid
+ *
+ * Description:
+ *   Context aware way to query hart id
+ *
+ * Returned Value:
+ *   Hart id
+ *
+ ****************************************************************************/
+
+uint64_t mpfs_mreg_hartid(void);
+
+#endif /* __ARCH_RISC_V_SRC_MPFS_MPFS_MREG_H_ */

--- a/arch/risc-v/src/mpfs/mpfs_scratch.c
+++ b/arch/risc-v/src/mpfs/mpfs_scratch.c
@@ -1,0 +1,120 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_scratch.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define HART_CNT    (5)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+struct mpfs_scratch_s
+{
+  uint64_t hartid;
+};
+
+static struct mpfs_scratch_s g_scratch[HART_CNT];
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mpfs_scratch_init
+ *
+ * Description:
+ *   Initialize the scratch area structures, should only be done on the boot
+ *   hart. Other harts should not access the scratch area before it is
+ *   initialized.
+ *
+ ****************************************************************************/
+
+void mpfs_scratch_init(void)
+{
+  int i;
+
+  for (i = 0; i < HART_CNT; i++)
+    {
+      g_scratch[i].hartid = i;
+    }
+}
+
+/****************************************************************************
+ * Name: mpfs_scratch_get
+ *
+ * Description:
+ *   Get pointer to scratch area for a specific hart. Use this during system
+ *   initialization to obtain pointer to hart specific scratch area. This
+ *   pointer can then be stored into the hart's context specific scracth
+ *   register.
+ *
+ * Input Parameters:
+ *   hartid - Hart number
+ *
+ * Returned Value:
+ *   Pointer to scratch area. Store this to the m/sscratch register.
+ *
+ ****************************************************************************/
+
+uintptr_t mpfs_scratch_get_addr(uint64_t hartid)
+{
+  /* Hart IDs go from 0...4 */
+
+  if (hartid < HART_CNT)
+    {
+      return (uintptr_t) &g_scratch[hartid];
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: mpfs_scratch_get_hartid
+ *
+ * Description:
+ *   Get harts own hartid by reading it from the scratch area. This is safe
+ *   to use from lower privilege modes (than M-mode).
+ *
+ * Input Parameters:
+ *   scratch - Pointer to scratch area
+ *
+ * Returned Value:
+ *   Hart id
+ *
+ ****************************************************************************/
+
+uint64_t mpfs_scratch_get_hartid(uintptr_t scratch)
+{
+  DEBUGASSERT(scratch >= (uintptr_t) &g_scratch &&
+              scratch <= (uintptr_t) &g_scratch + sizeof(g_scratch));
+
+  return ((struct mpfs_scratch_s *)scratch)->hartid;
+}
+

--- a/arch/risc-v/src/mpfs/mpfs_scratch.h
+++ b/arch/risc-v/src/mpfs/mpfs_scratch.h
@@ -1,0 +1,113 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_scratch.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISC_V_SRC_MPFS_MPFS_SCRATCH_H_
+#define __ARCH_RISC_V_SRC_MPFS_MPFS_SCRATCH_H_
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+#include <nuttx/arch.h>
+
+/****************************************************************************
+ * Name: mpfs_scratch_init
+ *
+ * Description:
+ *   Initialize the scratch area structures, should only be done on the boot
+ *   hart. Other harts should not access the scratch area before it is
+ *   initialized.
+ *
+ ****************************************************************************/
+
+void mpfs_scratch_init(void);
+
+/****************************************************************************
+ * Name: mpfs_scratch_get
+ *
+ * Description:
+ *   Get pointer to scratch area for a specific hart. Use this during system
+ *   initialization to obtain pointer to hart specific scratch area. This
+ *   pointer can then be stored into the hart's context specific scracth
+ *   register.
+ *
+ * Input Parameters:
+ *   hartid - Hart number
+ *
+ * Returned Value:
+ *   Pointer to scratch area. Store this to the m/sscratch register.
+ *
+ ****************************************************************************/
+
+uintptr_t mpfs_scratch_get_addr(uint64_t hartid);
+
+/****************************************************************************
+ * Name: mpfs_scratch_get_hartid
+ *
+ * Description:
+ *   Get harts own hartid by reading it from the scratch area. This is safe
+ *   to use from lower privilege modes (than M-mode).
+ *
+ * Input Parameters:
+ *   scratch - Pointer to scratch area
+ *
+ * Returned Value:
+ *   Hart id
+ *
+ ****************************************************************************/
+
+uint64_t mpfs_scratch_get_hartid(uintptr_t scratch);
+
+/****************************************************************************
+ * Name: mpfs_set_hart_sscratch
+ *
+ * Description:
+ *   Utility function to set a harts own sscratch register with the scratch
+ *   memory area base
+ *
+ * Input Parameters:
+ *   scratch_base - Scratch area base address
+ *
+ ****************************************************************************/
+
+static inline void mpfs_set_hart_sscratch(uint64_t scratch_base)
+{
+  WRITE_CSR(sscratch, scratch_base);
+}
+
+/****************************************************************************
+ * Name: mpfs_get_hart_sscratch
+ *
+ * Description:
+ *   Read a harts own sscratch register
+ *
+ * Returned Value:
+ *   sscratch register value
+ *
+ ****************************************************************************/
+
+static inline uint64_t mpfs_get_hart_sscratch(void)
+{
+  return READ_CSR(sscratch);
+}
+
+#endif /* __ARCH_RISC_V_SRC_MPFS_MPFS_SCRATCH_H_ */

--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -34,6 +34,7 @@
 #include "mpfs_ddr.h"
 #include "mpfs_cache.h"
 #include "mpfs_userspace.h"
+#include "mpfs_scratch.h"
 #include "riscv_arch.h"
 
 /****************************************************************************
@@ -73,7 +74,7 @@ extern void mpfs_cpu_boot(uint32_t);
  * Name: __mpfs_start
  ****************************************************************************/
 
-void __mpfs_start(uint32_t mhartid)
+void __mpfs_start(uint64_t mhartid)
 {
   const uint32_t *src;
   uint32_t *dest;
@@ -125,6 +126,14 @@ void __mpfs_start(uint32_t mhartid)
   /* Do board initialization */
 
   mpfs_boardinitialize();
+
+  /* Initialize scratch area */
+
+  if (mhartid != 0)
+    {
+      mpfs_scratch_init();
+      mpfs_set_hart_sscratch(mpfs_scratch_get_addr(mhartid));
+    }
 
   /* Initialize the caches.  Should only be executed from E51 (hart 0) to be
    * functional.  Consider the caches already configured if running without


### PR DESCRIPTION
Preparation for S-mode, provide access to mhartid via the supervisor
scratch register.
