### PR TITLE
Revert "tools: add option to reuse boards common files for custom boa…

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -151,9 +151,6 @@ else
 endif
 
 BOARD_COMMON_DIR ?= $(wildcard $(BOARD_DIR)$(DELIM)..$(DELIM)common)
-ifeq ($(BOARD_COMMON_DIR),)
-  BOARD_COMMON_DIR = $(wildcard $(TOPDIR)$(DELIM)boards$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)$(DELIM)common)
-endif
 BOARD_DRIVERS_DIR ?= $(wildcard $(BOARD_DIR)$(DELIM)..$(DELIM)drivers)
 ifeq ($(BOARD_DRIVERS_DIR),)
   BOARD_DRIVERS_DIR = $(TOPDIR)$(DELIM)drivers$(DELIM)dummy


### PR DESCRIPTION
…rds"

This reverts commit f77956a227f1db6ecb44eda3814e7b02aa2187a6.

## Summary

I didn't want to start digging in to how to fix building PX4 with upstream nuttx. This is the commit which breaks it, so I'd rather just revert it