### PR TITLE
Fix the initial idle tasks environment

### DIFF
--- a/include/nuttx/kmalloc.h
+++ b/include/nuttx/kmalloc.h
@@ -123,6 +123,11 @@ extern "C"
 
 FAR void *group_malloc(FAR struct task_group_s *group, size_t nbytes);
 
+/* Functions defined in group/group_realloc.c *******************************/
+
+FAR void *group_realloc(FAR struct task_group_s *group, FAR void *oldmem,
+                        size_t newsize);
+
 /* Functions defined in group/group_zalloc.c ********************************/
 
 FAR void *group_zalloc(FAR struct task_group_s *group, size_t nbytes);

--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -94,7 +94,7 @@ int env_dup(FAR struct task_group_s *group)
         {
           /* There is an environment, duplicate it */
 
-          envp = (FAR char *)kumm_malloc(envlen);
+          envp = (FAR char *)group_malloc(ptcb->group, envlen);
           if (envp == NULL)
             {
               /* The parent's environment can not be inherited due to a

--- a/sched/environ/env_setenv.c
+++ b/sched/environ/env_setenv.c
@@ -145,7 +145,7 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
   if (group->tg_envp)
     {
       newsize = group->tg_envsize + varlen;
-      newenvp = (FAR char *)kumm_realloc(group->tg_envp, newsize);
+      newenvp = group_realloc(group, group->tg_envp, newsize);
       if (!newenvp)
         {
           ret = ENOMEM;
@@ -157,7 +157,7 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
   else
     {
       newsize = varlen;
-      newenvp = (FAR char *)kumm_malloc(varlen);
+      newenvp = (FAR char *)group_malloc(group, varlen);
       if (!newenvp)
         {
           ret = ENOMEM;

--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -86,7 +86,7 @@ int unsetenv(FAR const char *name)
 
           if (group->tg_envp != NULL)
             {
-              kumm_free(group->tg_envp);
+              group_free(group, group->tg_envp);
               group->tg_envp = NULL;
             }
 
@@ -96,7 +96,9 @@ int unsetenv(FAR const char *name)
         {
           /* Reallocate the environment to reclaim a little memory */
 
-          newenvp = (FAR char *)kumm_realloc(group->tg_envp, newsize);
+          newenvp = (FAR char *)group_realloc(group, group->tg_envp,
+                                              newsize);
+
           if (newenvp == NULL)
             {
               set_errno(ENOMEM);

--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -50,7 +50,7 @@ CSRCS += group_exitinfo.c
 endif
 
 ifneq ($(CONFIG_BUILD_FLAT),y)
-CSRCS += group_malloc.c group_zalloc.c group_free.c
+CSRCS += group_malloc.c group_realloc.c group_zalloc.c group_free.c
 endif
 
 # Include group build support

--- a/sched/group/group_realloc.c
+++ b/sched/group/group_realloc.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/environ/env_release.c
+ * sched/group/group_realloc.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -22,62 +22,62 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <sys/types.h>
 
-#ifndef CONFIG_DISABLE_ENVIRON
-
-#include <sched.h>
 #include <assert.h>
-#include <errno.h>
 
+#include <nuttx/sched.h>
 #include <nuttx/kmalloc.h>
 
-#include "environ/environ.h"
+#include "sched/sched.h"
+#include "group/group.h"
+
+#ifdef CONFIG_MM_KERNEL_HEAP
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: env_release
+ * Name: group_realloc
  *
  * Description:
- *   env_release() is called only from group_leave() when the last member of
- *   a task group exits.  The env_release() function clears the environment
- *   of all name-value pairs and sets the value of the external variable
- *   environ to NULL.
- *
- * Input Parameters:
- *   group - Identifies the task group containing the environment structure
- *           to be released.
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   Not called from an interrupt handler
+ *   Re-allocate memory appropriate for the group type.  If the memory is
+ *   part of a privileged group, then it should be allocated so that it
+ *   is only accessible by privileged code;  Otherwise, it is a user mode
+ *   group and must be allocated so that it accessible by unprivileged
+ *   code.
  *
  ****************************************************************************/
 
-void env_release(FAR struct task_group_s *group)
+FAR void *group_realloc(FAR struct task_group_s *group, FAR void *oldmem,
+                        size_t newsize)
 {
-  DEBUGASSERT(group != NULL);
+  /* A NULL group pointer means the current group */
 
-  /* Free any allocate environment strings */
-
-  if (group->tg_envp)
+  if (!group)
     {
-      /* Free the environment */
-
-      group_free(group, group->tg_envp);
+      FAR struct tcb_s *tcb = this_task();
+      DEBUGASSERT(tcb && tcb->group);
+      group = tcb->group;
     }
 
-  /* In any event, make sure that all environment-related variables in the
-   * task group structure are reset to initial values.
-   */
+  /* Check the group type */
 
-  group->tg_envsize = 0;
-  group->tg_envp = NULL;
+  if ((group->tg_flags & GROUP_FLAG_PRIVILEGED) != 0)
+    {
+      /* It is a privileged group... use the kernel mode memory allocator */
+
+      return kmm_realloc(oldmem, newsize);
+    }
+  else
+    {
+      /* This is an unprivileged group... use the user mode memory
+       * allocator.
+       */
+
+      return kumm_realloc(oldmem, newsize);
+    }
 }
 
-#endif /* CONFIG_DISABLE_ENVIRON */
+#endif /* CONFIG_MM_KERNEL_HEAP */

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -589,7 +589,8 @@ void nx_start(void)
        */
 
       DEBUGVERIFY(group_initialize(&g_idletcb[i]));
-      g_idletcb[i].cmn.group->tg_flags = GROUP_FLAG_NOCLDWAIT;
+      g_idletcb[i].cmn.group->tg_flags = (GROUP_FLAG_NOCLDWAIT |
+                                          GROUP_FLAG_PRIVILEGED);
     }
 
   g_lastpid = CONFIG_SMP_NCPUS - 1;


### PR DESCRIPTION
- User mode allocator was used for setting up the environment. This
  works in flat mode and probably in protected mode as well, as there
  is always a a single user allocator present
- This does not work in kernel mode, where each user task has its own
  heap allocator. Also, when the idle tasks environment is being set,
  no allocator is ready and the system crashes at once.

Fix this by using the group allocators instead:
- Idle task is a kernel task, so its group is privileged
- Add group_realloc
- Use the group_malloc/realloc functions instead of kumm_malloc

## Summary

## Impact

## Testing

