### PR TITLE
env_dup: Fix copying of env between address environments

### DIFF
--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -24,7 +24,7 @@ include $(TOPDIR)/Make.defs
 
 CSRCS  = binfmt_globals.c binfmt_initialize.c binfmt_register.c binfmt_unregister.c
 CSRCS += binfmt_loadmodule.c binfmt_unloadmodule.c binfmt_execmodule.c
-CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_dumpmodule.c
+CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_copyenv.c binfmt_dumpmodule.c
 CSRCS += binfmt_coredump.c
 
 ifeq ($(CONFIG_BINFMT_LOADABLE),y)

--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -118,6 +118,46 @@ void binfmt_freeargv(FAR char * const *argv);
 #endif
 
 /****************************************************************************
+ * Name: binfmt_copyenv
+ *
+ * Description:
+ *   In the kernel build, the environment exists in the parent's address
+ *   environment and, hence, will be inaccessible when we switch to the
+ *   address environment of the new process. So we do not have any real
+ *   option other than to copy the parents envp list into an intermediate
+ *   buffer that resides in neutral kernel memory.
+ *
+ * Input Parameters:
+ *   envp     - Allocated environment strings
+ *
+ * Returned Value:
+ *   A non-zero copy is returned on success.
+ *
+ ****************************************************************************/
+
+FAR char * const *binfmt_copyenv(FAR char * const *envp);
+
+/****************************************************************************
+ * Name: binfmt_freeenv
+ *
+ * Description:
+ *   Release the copied envp[] list.
+ *
+ * Input Parameters:
+ *   envp     - Allocated environment strings
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+void binfmt_freeenv(FAR char * const *envp);
+#else
+#  define binfmt_freeenv(argv)
+#endif
+
+/****************************************************************************
  * Name: builtin_initialize
  *
  * Description:

--- a/binfmt/binfmt_copyenv.c
+++ b/binfmt/binfmt_copyenv.c
@@ -1,0 +1,120 @@
+/****************************************************************************
+ * binfmt/binfmt_copyenv.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <string.h>
+#include <debug.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/sched.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: binfmt_copyenv
+ *
+ * Description:
+ *   In the kernel build, the environment exists in the parent's address
+ *   environment and, hence, will be inaccessible when we switch to the
+ *   address environment of the new process. So we do not have any real
+ *   option other than to copy the parents envp list into an intermediate
+ *   buffer that resides in neutral kernel memory.
+ *
+ * Input Parameters:
+ *   envp     - Allocated environment strings
+ *
+ * Returned Value:
+ *   A non-zero copy is returned on success.
+ *
+ ****************************************************************************/
+
+FAR char * const *binfmt_copyenv(FAR char * const *envp)
+{
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+  /* In this case the current task must be the one we are copying */
+
+  FAR struct tcb_s *ptcb = nxsched_self();
+  FAR char *envcp = (FAR char *) envp;
+  size_t envlen;
+
+  /* Check that the parent has a group and an environment */
+
+  if (ptcb->group != NULL && ptcb->group->tg_envp != NULL)
+    {
+      envlen = ptcb->group->tg_envsize;
+
+      if (envlen > 0)
+        {
+          envcp = (FAR char *)kmm_malloc(envlen);
+          if (!envcp)
+            {
+              berr("ERROR: Failed to allocate the environment buffer\n");
+              return NULL;
+            }
+
+          /* Copy envp to the kernel allocated buffer */
+
+          memcpy(envcp, ptcb->group->tg_envp, envlen);
+        }
+    }
+
+  return (FAR char * const *)envcp;
+#else
+  /* Just return the original */
+
+  return envp;
+#endif
+}
+
+/****************************************************************************
+ * Name: binfmt_freeenv
+ *
+ * Description:
+ *   Release the copied envp[] list.
+ *
+ * Input Parameters:
+ *   envp     - Allocated environment strings
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+void binfmt_freeenv(FAR char * const *envp)
+{
+  if (envp)
+    {
+      kmm_free((FAR char *)envp);
+    }
+}
+#endif
+#endif /* CONFIG_BINFMT_DISABLE */

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -931,6 +931,7 @@ FAR struct streamlist *nxsched_get_streams(void);
  *   argv       - A pointer to an array of input parameters.  The array
  *                should be terminated with a NULL argv[] value. If no
  *                parameters are required, argv may be NULL.
+ *   envp       - A pointer to the program's environment, envp may be NULL
  *
  * Returned Value:
  *   OK on success; negative error value on failure appropriately.  (See
@@ -943,7 +944,7 @@ FAR struct streamlist *nxsched_get_streams(void);
 
 int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 FAR void *stack, uint32_t stack_size, main_t entry,
-                FAR char * const argv[]);
+                FAR char * const argv[], FAR char * const envp[]);
 
 /****************************************************************************
  * Name: nxtask_uninit

--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -61,7 +61,7 @@
  *
  ****************************************************************************/
 
-int env_dup(FAR struct task_group_s *group)
+int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
 {
   FAR struct tcb_s *ptcb = this_task();
   FAR char *envp = NULL;
@@ -108,7 +108,11 @@ int env_dup(FAR struct task_group_s *group)
             {
               /* Duplicate the parent environment. */
 
-              memcpy(envp, ptcb->group->tg_envp, envlen);
+              if (envcp == NULL)
+                {
+                  envcp = (FAR char * const *)ptcb->group->tg_envp;
+                }
+              memcpy(envp, envcp, envlen);
             }
         }
 

--- a/sched/environ/environ.h
+++ b/sched/environ/environ.h
@@ -74,7 +74,7 @@ extern "C"
  *
  ****************************************************************************/
 
-int env_dup(FAR struct task_group_s *group);
+int env_dup(FAR struct task_group_s *group, FAR char * const *envp);
 
 /****************************************************************************
  * Name: env_release

--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -20,6 +20,7 @@
 
 CSRCS += group_create.c group_join.c group_leave.c group_find.c
 CSRCS += group_setupstreams.c group_setupidlefiles.c group_setuptaskfiles.c
+CSRCS += group_setupenv.c
 CSRCS += group_foreachchild.c group_killchildren.c group_signal.c
 
 ifeq ($(CONFIG_SCHED_HAVE_PARENT),y)

--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -134,6 +134,7 @@ void group_remove_children(FAR struct task_group_s *group);
 
 /* Group data resource configuration */
 
+int  group_setupenv(FAR struct task_tcb_s *tcb, FAR char * const *envp);
 int  group_setupidlefiles(FAR struct task_tcb_s *tcb);
 int  group_setuptaskfiles(FAR struct task_tcb_s *tcb);
 #ifdef CONFIG_FILE_STREAM

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -37,7 +37,6 @@
 #include <nuttx/sched.h>
 #include <nuttx/tls.h>
 
-#include "environ/environ.h"
 #include "sched/sched.h"
 #include "group/group.h"
 
@@ -201,15 +200,6 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 
   group_inherit_identity(group);
 
-  /* Duplicate the parent tasks environment */
-
-  ret = env_dup(group);
-  if (ret < 0)
-    {
-      tcb->cmn.group = NULL;
-      goto errout_with_taskinfo;
-    }
-
   /* Initial user space semaphore */
 
   nxsem_init(&group->tg_info->ta_sem, 0, 1);
@@ -243,8 +233,6 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 
   return OK;
 
-errout_with_taskinfo:
-  group_free(group, group->tg_info);
 errout_with_member:
 #ifdef HAVE_GROUP_MEMBERS
   kmm_free(group->tg_members);

--- a/sched/group/group_setupenv.c
+++ b/sched/group/group_setupenv.c
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * sched/group/group_setupenv.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sched.h>
+#include <assert.h>
+
+#include "environ/environ.h"
+#include "sched/sched.h"
+#include "group/group.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: group_setupenv
+ * Description:
+ *   Copy the internal environment structure of a parent task to its newly
+ *   created child task's internal environment.
+ *
+ * Input Parameters:
+ *   tcb - TCB of the newly created task, which is considered as a child of
+ *   the current task.
+ *
+ * Returned Value:
+ *   Zero on success
+ *
+ ****************************************************************************/
+
+int group_setupenv(FAR struct task_tcb_s *tcb, FAR char * const *envp)
+{
+  return env_dup(tcb->cmn.group, envp);
+}

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -91,7 +91,8 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, name, priority, stack_ptr, stack_size, entry, argv);
+  ret = nxtask_init(tcb, name, priority, stack_ptr, stack_size, entry, argv,
+                    NULL);
   if (ret < OK)
     {
       kmm_free(tcb);

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -83,7 +83,8 @@
 
 int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 FAR void *stack, uint32_t stack_size,
-                main_t entry, FAR char * const argv[])
+                main_t entry, FAR char * const argv[],
+                FAR char * const envp[])
 {
   uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
   FAR struct tls_info_s *info;
@@ -101,6 +102,14 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
   if (ret < 0)
     {
       return ret;
+    }
+
+  /* Duplicate the parent tasks environment */
+
+  ret = group_setupenv(tcb, envp);
+  if (ret < 0)
+    {
+      goto errout_with_group;
     }
 
   /* Associate file descriptors with the new task */


### PR DESCRIPTION
If address environments are in use, it is not possible to simply
memcpy from from one process to another. The current implementation
of env_dup does precisely this and thus, it fails at once when it is
attempted between two user processes.

The solution is to use the kernel's heap as an intermediate buffer.
This is a simple, effective and common way to do a fork().

Obviously this is not needed for kernel processes.

## Summary

## Impact

## Testing

