### PR TITLE
[REVERTME] Force PF eMMC always to 25MHz

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -1829,7 +1829,7 @@ static void mpfs_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
     /* Enable normal MMC operation clocking */
 
     case CLOCK_MMC_TRANSFER:
-      clckr = MPFS_MMC_CLOCK_200MHZ;
+      clckr = MPFS_MMC_CLOCK_25MHZ;
       break;
 
     /* SD normal operation clocking (wide 4-bit mode) */


### PR DESCRIPTION
This is a hack to make eMMC work for saluki.

The HS200 mode is currently broken;
1) the driver doesn't seem to switch to that
2) there is (most likely) bus training needed for the mode

This makes the eMMC usable until the mpfs_emmcsd is properly fixed

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>



