### PR TITLE
mpfs: Remove the ddrstorage section from the OpenSBI package

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -59,14 +59,6 @@
 #define MPFS_PMP_DEFAULT_ADDR      0xfffffffff
 #define MPFS_PMP_DEFAULT_PERM      0x000000009f
 
-/* The following define is not accessible with assember.  Make sure it's in
- * sync with the assembler usage in mpfs_opensbi_utils.S.
- */
-
-#if SBI_PLATFORM_DEFAULT_HART_STACK_SIZE != 8192
-#  error "Fix define in file mpfs_opensbi_utils.S"
-#endif
-
 #define MPFS_SYSREG_SOFT_RESET_CR     (MPFS_SYSREG_BASE + \
                                        MPFS_SYSREG_SOFT_RESET_CR_OFFSET)
 #define MPFS_SYSREG_SUBBLK_CLOCK_CR   (MPFS_SYSREG_BASE + \
@@ -232,14 +224,8 @@ static const struct sbi_platform platform =
 
 /* This must go into l2_scratchpad region, starting at 0x0a000000. */
 
-static sbi_scratch_holder_t g_scratches[MPFS_MAX_NUM_HARTS] \
+sbi_scratch_holder_t g_scratches[MPFS_MAX_NUM_HARTS] \
                __attribute__((section(".l2_scratchpad")));
-
-/* These stacks are used in the mpfs_opensbi_utils.S */
-
-uint8_t g_hart_stacks[SBI_PLATFORM_DEFAULT_HART_STACK_SIZE * \
-                      MPFS_HART_COUNT] \
-                      __attribute__((section(".ddrstorage"), aligned(16)));
 
 static const uint64_t sbi_entrypoints[] =
 {

--- a/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
@@ -46,10 +46,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef SBI_PLATFORM_DEFAULT_HART_STACK_SIZE
-#define SBI_PLATFORM_DEFAULT_HART_STACK_SIZE 8192
-#endif
-
 /****************************************************************************
  * Public Symbols
  ****************************************************************************/
@@ -100,13 +96,14 @@ mpfs_opensbi_prepare_hart:
   la   t0, mpfs_global_pointer
   ld   gp, 0(t0)
 
-  /* Setup stacks per hart */
+  /* Setup stacks per hart, the stack top is the end of the hart's scratch */
 
   csrr a0, mhartid
-  li   t1, SBI_PLATFORM_DEFAULT_HART_STACK_SIZE
+  li   t1, SBI_SCRATCH_SIZE
   mul  t0, a0, t1
-  la   sp, g_hart_stacks
+  la   sp, g_scratches
   add  sp, sp, t0
+  add  sp, sp, t1
   jal  mpfs_opensbi_setup
 
 /****************************************************************************

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -20,7 +20,6 @@
 
 MEMORY
 {
-    ddr  (rx)     : ORIGIN = 0x80000000, LENGTH = 4M          /* w/ cache */
     envm (rx)     : ORIGIN = 0x20220100, LENGTH = 128K - 256  /* 256 reserved for hss headers */
     l2lim  (rwx)  : ORIGIN = 0x08000000, LENGTH = 1024k
     l2zerodevice (rwx) : ORIGIN = 0x0A000000, LENGTH = 512k
@@ -37,10 +36,6 @@ SECTIONS
       riscv_atomic*
       riscv_locks*
       riscv_asm*
-    } > ddr
-
-    .ddrstorage : {
-      *(.ddrstorage)
     } > ddr
 
     .l2_scratchpad : ALIGN(0x10)

--- a/tools/mpfs/Config.mk
+++ b/tools/mpfs/Config.mk
@@ -27,11 +27,11 @@
 ifeq ($(CONFIG_MPFS_OPENSBI),y)
 define POSTBUILD
 	$(Q) echo "SBI: Creating nuttx.sbi file"
-	$(Q) $(OBJCOPY) -O binary -j .text.sbi -j .ddrstorage $(BIN) nuttx.sbi
+	$(Q) $(OBJCOPY) -O binary -j .text.sbi $(BIN) nuttx.sbi
 	$(Q) ([ $$? -eq 0 ] && echo "Done.")
 	$(Q) echo nuttx.sbi >> nuttx.manifest
 	$(Q) echo "SBI: Removing unnecessary sections from nuttx binary"
-	$(Q) $(OBJCOPY) -O binary -R .text.sbi -R .l2_scratchpad -R .ddrstorage $(BIN) nuttx.bin
+	$(Q) $(OBJCOPY) -O binary -R .text.sbi -R .l2_scratchpad $(BIN) nuttx.bin
 	$(Q) ([ $$? -eq 0 ] && echo "Done.")
 endef
 endif


### PR DESCRIPTION
It is not really needed; g_hart_stacks is only used during SBI init as
a temporary stack area. We can use the scratch area buffers for this, as
the scratch areas define almost 4K of extra space, which is used for
exception stacks anyway.

## Summary

## Impact

## Testing

