### PR TITLE
mpfs_head.S: Mark .start section attributes explicitly

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -38,7 +38,7 @@
 
   .extern __trap_vec
 
-  .section .start
+  .section .start, "ax"
   .global __start
 
 __start:

--- a/arch/risc-v/src/mpfs/mpfs_shead.S
+++ b/arch/risc-v/src/mpfs/mpfs_shead.S
@@ -38,7 +38,7 @@
 
   .extern __trap_vec
 
-  .section .start
+  .section .start, "ax"
   .global __start
 
 /****************************************************************************


### PR DESCRIPTION
a = allocated, x = executable. Otherwise the input section type will
become empty, which means output section will be empty as well.

