### PR TITLE
libelf/libelf_symbols.c: Fix compilation warning about void* arithmetics

### DIFF
--- a/binfmt/libelf/libelf_symbols.c
+++ b/binfmt/libelf/libelf_symbols.c
@@ -307,7 +307,7 @@ int elf_symvalue(FAR struct elf_loadinfo_s *loadinfo, FAR Elf_Sym *sym,
               "%08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
               loadinfo->iobuffer, (uintptr_t)sym->st_value,
               (uintptr_t)symbol->sym_value,
-              (uintptr_t)(sym->st_value + symbol->sym_value));
+              (uintptr_t)(sym->st_value + (uintptr_t)symbol->sym_value));
 
         sym->st_value += ((uintptr_t)symbol->sym_value);
       }


### PR DESCRIPTION
Fixes minor issue with a trace (build failure with -Werror): libelf/libelf_symbols.c:310:41: error: pointer of type 'void *' used in arithmetic [-Werror=pointer-arith]
  310 |               (uintptr_t)(sym->st_value + symbol->sym_value));
