### PR TITLE
arch/risc-v/src/mpfs: Add a config option for enabling L2 cache

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -157,6 +157,13 @@ config MPFS_DDR_TYPE
 	default 3 if MPFS_DDR_TYPE_LPDDR3
 	default 4 if MPFS_DDR_TYPE_LPDDR4
 
+config MPFS_ENABLE_CACHE
+	bool "Enable L2 cache"
+	depends on MPFS_BOOTLOADER
+	default y
+	---help---
+		Enables L2 cache in L2LIM memory
+
 config MPFS_EMMCSD_MUX_GPIO
 	bool "GPIO driven EMMCSD mux"
 	default n

--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -161,7 +161,7 @@ void __mpfs_start(uint64_t mhartid)
    * the CONFIG_MPFS_BOOTLOADER -option.
    */
 
-#ifdef CONFIG_MPFS_BOOTLOADER
+#ifdef CONFIG_MPFS_ENABLE_CACHE
   if (mhartid == 0)
     {
       mpfs_enable_cache();


### PR DESCRIPTION
Make a separate config flag for enabling L2 cache. This is on by default when compiling a standalone/bootloader configuration, but can also be disabled for special cases, such as memory testing

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>


