### PR TITLE
caninfo print out type fix

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -556,7 +556,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
   FAR struct can_dev_s     *dev = inode->i_private;
 #endif
 
-  caninfo("buflen: %d\n", buflen);
+  caninfo("buflen: %lu\n", buflen);
 
   /* The caller must provide enough memory to catch the smallest possible
    * message.  This is not a system error condition, but we won't permit
@@ -793,7 +793,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
   int                      msglen;
   int                      ret   = 0;
 
-  caninfo("buflen: %d\n", buflen);
+  caninfo("buflen: %lu\n", buflen);
 
   /* Interrupts must disabled throughout the following */
 


### PR DESCRIPTION
- buflen is long unsigned int therefore `%lu`. `%d` would trigger -Werror=format= error when building px4-firmware
- Needed for https://github.com/tiiuae/nuttx/pull/71 as requested here https://github.com/tiiuae/nuttx/pull/68#discussion_r998074669

