### PR TITLE
arch/arm/src/stm32f7/stm32_i2c.c: Round up stm32_i2c_toticks return v…

### DIFF
--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -782,11 +782,12 @@ static uint32_t stm32_i2c_toticks(int msgc, struct i2c_msg_s *msgs)
       bytecount += msgs[i].length;
     }
 
-  /* Then return a number of microseconds based on a user provided scaling
-   * factor.
+  /* Then return a number of ticks based on a user provided scaling
+   * factor, rounded up.
    */
 
-  return USEC2TICK(CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE * bytecount);
+  return USEC2TICK(CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE * bytecount +
+                   CONFIG_USEC_PER_TICK / 2 - 1);
 }
 #endif
 


### PR DESCRIPTION
…alue

When sending small number of bytes with larger CONFIG_USEC_PER_TICK this function should return at least 1. Solve this by rounding up the result.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Summary

## Impact

## Testing

