### PR TITLE
mpfs/Kconfig: fix typo on config file

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -707,7 +707,7 @@ config ARCH_MPU_HAS_NAPOT
 	default y
 
 config MPFS_CRYPTO
-	bool "Enable MPFS HW crypto
+	bool "Enable MPFS HW crypto"
 	default n
 
 #if MPFS_CRYPTO


### PR DESCRIPTION
Fixes typo in kconfig
