### PR TITLE
mpfs/mpfs_mm_init: Add the MTIME user mapping for kernel mode as well

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_mm_init.c
+++ b/arch/risc-v/src/mpfs/mpfs_mm_init.c
@@ -54,9 +54,9 @@
 #define PGT_L2_VBASE    PGT_L2_PBASE
 #define PGT_L3_VBASE    PGT_L3_PBASE
 
-#define PGT_L1_SIZE     (512)  /* Enough to map 512 GiB */
-#define PGT_L2_SIZE     (512)  /* Enough to map 1 GiB */
-#define PGT_L3_SIZE     (1024) /* Enough to map 4 MiB */
+#define PGT_L1_SIZE     (512)       /* Enough to map 512 GiB */
+#define PGT_L2_SIZE     (512)       /* Enough to map 1 GiB */
+#define PGT_L3_SIZE     (40 * 1024) /* Enough to map 40 MiB */
 
 /* Calculate the minimum size for the L3 table */
 
@@ -251,4 +251,9 @@ void mpfs_kernel_mappings(void)
 
   mmu_ln_map_region(2, PGT_L2_VBASE, PGPOOL_START, PGPOOL_START, PGPOOL_SIZE,
                     MMU_KDATA_FLAGS);
+
+  /* Map the MTIME counter to the start of USR IO region */
+
+  map_region(MPFS_CLINT_MTIME & (~RV_MMU_PAGE_MASK), USRIO_START,
+             RV_MMU_PAGE_SIZE, PTE_R | PTE_U | PTE_G);
 }

--- a/arch/risc-v/src/mpfs/mpfs_userspace.c
+++ b/arch/risc-v/src/mpfs/mpfs_userspace.c
@@ -251,7 +251,8 @@ static void configure_mmu(void)
 
   /* Map the MTIME counter to the start of USR IO region */
 
-  map_region(MPFS_CLINT_MTIME & (~RV_MMU_PAGE_MASK), USRIO_START, RV_MMU_PAGE_SIZE, PTE_R | PTE_U | PTE_G);
+  map_region(MPFS_CLINT_MTIME & (~RV_MMU_PAGE_MASK), USRIO_START,
+             RV_MMU_PAGE_SIZE, PTE_R | PTE_U | PTE_G);
 
   /* Connect the L1 and L2 page tables */
 

--- a/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
@@ -28,6 +28,7 @@ MEMORY
     kflash (rx) : ORIGIN = 0x80000000, LENGTH = 2048K   /* w/ cache */
     ksram (rwx) : ORIGIN = 0x80200000, LENGTH = 2048K   /* w/ cache */
     pgram (rwx) : ORIGIN = 0x80400000, LENGTH = 4096K   /* w/ cache */
+    usrio (r)   : ORIGIN = 0x80800000, LENGTH = 32K     /* w/ cache */
 }
 
 OUTPUT_ARCH("riscv")
@@ -44,6 +45,11 @@ __ksram_end = ORIGIN(ksram) + LENGTH(ksram);
 
 __pgheap_start = ORIGIN(pgram);
 __pgheap_size = LENGTH(pgram);
+
+/* User I/O */
+
+__usrio_start = ORIGIN(usrio);
+__usrio_size = LENGTH(usrio);
 
 ENTRY(_stext)
 EXTERN(__start)


### PR DESCRIPTION
## Summary
Just a temporary patch, need to implement some kind of scalable solution for this. It might be a good idea to map something else for the user to avoid using ecall to enter the kernel for simple reads ?

Also, increase the L3 table size

NOTE: Need to figure out some kind of scalable solution for this, the idea to provide a user I/O area is solid
## Impact
Enables USRIO for kernel build
## Testing
px4 kernel mode
