### PR TITLE
clear spi int before the transfer starts

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_spi.c
+++ b/arch/risc-v/src/mpfs/mpfs_spi.c
@@ -1278,6 +1278,7 @@ static int mpfs_spi_irq(int cpuint, void *context, void *arg)
   if (status & MPFS_SPI_TXDONEMSKINT)
     {
       remaining = priv->txwords - priv->tx_pos;
+      putreg32(MPFS_SPI_TXDONECLR, MPFS_SPI_INT_CLEAR);
 
       if (remaining == 0)
         {
@@ -1300,8 +1301,6 @@ static int mpfs_spi_irq(int cpuint, void *context, void *arg)
               mpfs_spi_load_tx_fifo(priv, priv->txbuf, priv->fifolevel);
             }
         }
-
-      putreg32(MPFS_SPI_TXDONECLR, MPFS_SPI_INT_CLEAR);
     }
 
   if (status & MPFS_SPI_RXCHOVRFMSKINT)


### PR DESCRIPTION
## Summary
In spi_irq handler the data is written into txfifo and transfer is started before the TXDONE interrupt is cleared. If the bus/memory access is in some cases delayed, the SPI transfer can have been finished already before the interrupt register is cleaned for the transfer.

## Impact
Previous implementation leads the early arrived interrupt to be just removed and never handled, which would cause a timeout error.
This fix moves the clearing of the interrupt to the place before the TX is started, so the interrupt is not missed in above cases.

## Testing
Fix is tested in dual OS system (Nuttx & Linux), where high CPU load in other OS slows down the bus/memory accesses in Nuttx side. This test setup triggers the SPI TX Timeout errors while reading peripheral registers via SPI bus. With this fix there are no SPI TX timeout errors seen in the same situation.

