### PR TITLE
arch/riscv/src/mpfs/mpfs_ethernet.c: discard err rxframe in int work

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -1063,13 +1063,6 @@ static void mpfs_interrupt_work(void *arg)
       uint32_t rx_error = 0;
       ninfo("RX: rsr=0x%X\n", rsr);
 
-      if ((rsr & RECEIVE_STATUS_FRAME_RECEIVED) != 0)
-        {
-          /* Handle the received packet */
-
-          mpfs_receive(priv, queue);
-        }
-
       /* Check for Receive Overrun */
 
       if ((rsr & RECEIVE_STATUS_RECEIVE_OVERRUN) != 0)
@@ -1110,6 +1103,12 @@ static void mpfs_interrupt_work(void *arg)
           regval = mac_getreg(priv, NETWORK_CONTROL);
           regval |= NETWORK_CONTROL_ENABLE_RECEIVE;
           mac_putreg(priv, NETWORK_CONTROL, regval);
+        }
+      else if ((rsr & RECEIVE_STATUS_FRAME_RECEIVED) != 0)
+        {
+          /* Handle the received packet only in case there are no RX errors */
+
+          mpfs_receive(priv, queue);
         }
     }
 


### PR DESCRIPTION
## Summary
There is possible deadlock situation in mpfs_network module. 
In case mpfs_receive is called, it keeps waiting for complete frame and also keeps the net_lock locked. In the mean while, the TX may run out of free descriptors, but can not get net_lock mutex lock to be able to release used descriptors. If there are no free TX descs it disables RX interrupts because it may require to send response to the received frame.
So, TX side keeps RX interrupts disabled due to lack of free descriptors and RX blocks TX to release those descs by stubbornly waiting for complete frame.

Workaround is to discard RX frame already in mpfs_interrupt_work function in case there are RX errors detected. This prevents receive method to reserve net_lock mutex in case there is no complete frame available, so TX can still lock the mutex to release used descriptors.

This is just a workaround and it may not completely remove the deadlock from the code, but just reduce the possibility to make it happen. There shall be another solution to remove the deadlock situation completely.

## Impact
Ethernet stops working in case the deadlock occurs

## Testing
Loading cpu and eth RX/TX heavily to cause OVERRUN errors in RX side while making also TX to use lot of descriptors by sending lot of data out. Running PX4 HITL with eth gazebo mavlink connection is an easy way to trigger this deadlock.

