### PR TITLE
arch/risc-v/src/mpfs/crypto.defs: Update to include mpfs_systemservice.c

### DIFF
--- a/arch/risc-v/src/mpfs/crypto.defs
+++ b/arch/risc-v/src/mpfs/crypto.defs
@@ -8,7 +8,7 @@ context::$(MPFS_CRYPTO)
 distclean::
 	$(Q) rm -rf mpfs/crypto
 
-CHIP_CSRCS += mpfs_crypto.c
+CHIP_CSRCS += mpfs_crypto.c mpfs_systemservice.c
 
-DEPPATH += --dep-path crypto --dep-path mpfs/crypto
-VPATH += :crypto:mpfs/crypto
+DEPPATH += --dep-path mpfs/crypto
+VPATH += :mpfs/crypto


### PR DESCRIPTION
This adds mpfs_systemservice.c into build scripts. Note that the file exists only in private repository, and this crypto.defs file is only used when CONFIG_MPFS_CRYPTO=y (which can only be enabled when the private repository is cloned)

Also remove some unneeded paths from dependency paths

