### PR TITLE
workaround for emmc interrupt blackout issue

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -782,12 +782,22 @@ static void mpfs_sendfifo(struct mpfs_dev_s *priv)
        * come back when we're good to write again.
        */
 
-      if (priv->remaining && (!(getreg32(MPFS_EMMCSD_SRS09) &
-          MPFS_EMMCSD_SRS09_BWE)))
+      if (priv->remaining)
         {
-          modifyreg32(MPFS_EMMCSD_SRS14, 0, MPFS_EMMCSD_SRS14_BWR_IE);
+          /* Enable BWR before checking BWE bit */
+
           putreg32(MPFS_EMMCSD_SRS12_BWR, MPFS_EMMCSD_SRS12);
-          return;
+          modifyreg32(MPFS_EMMCSD_SRS14, 0, MPFS_EMMCSD_SRS14_BWR_IE);
+          if (!(getreg32(MPFS_EMMCSD_SRS09) & MPFS_EMMCSD_SRS09_BWE))
+            {
+              return;
+            }
+
+          /* There is still room for writing to buffer,
+           * disable BWR and continue.
+           */
+
+          modifyreg32(MPFS_EMMCSD_SRS14, MPFS_EMMCSD_SRS14_BWR_IE, 0);
         }
     }
 


### PR DESCRIPTION
Modified sendfifo() function to enable BWR_IE before checking if BWE is enabled.

In the sendfifo function there is a check if there is still remaining data to be sent and if the Buffer Write Enable status is cleared (not allowed to write more data to the buffer), the Buffer Write Ready interrupt is enabled status cleared, and function returns to wait for Buffer Write Ready. However, there is a tiny time window between the SRS09:BWE check and the SRS14:BWR int enabling where the interrupt can occur and it is then not detected causing Data Timeout error.