### PR TITLE
[REVERTME] arch/risc-v/src/mpfs/mpfs_corespi.c: Hack around a bug in …

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corespi.c
+++ b/arch/risc-v/src/mpfs/mpfs_corespi.c
@@ -661,7 +661,13 @@ static int mpfs_spi_sem_waitdone(struct mpfs_spi_priv_s *priv)
 {
   uint32_t timeout = SPI_TTOA_US(priv->txwords * priv->nbits, priv->actual);
   timeout += SPI_TTOA_MARGIN_US;
-  return nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout));
+
+  /* Hack: add +1 to timeout due to some bug in NuttX. It randomly timeouts
+   * one tick too early
+   */
+
+  return nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout) +
+                                        1);
 }
 
 /****************************************************************************


### PR DESCRIPTION
…nuttx nxsem_tickwait_uninterruptible bug

The nxsem_tickwait_uninterruptible seems to timeout randomly one tick too soon. Add one tick to timeout to make sure it is long enough.

This can be reverted when the actual bug is fixed.

## Summary

## Impact

## Testing

