### PR TITLE
2x can support: partial fix for iob semcount runaway 

### DIFF
--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -231,6 +231,19 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
   if ((iob = iob_peek_queue(&conn->readahead)) != NULL &&
       pstate->pr_buflen > 0)
     {
+      if (iob->io_flink != NULL ||
+          iob->io_pktlen == 0 ||
+          iob->io_offset <= 0)
+        {
+          if (iob->io_pktlen == 0 || iob->io_offset <= 0)
+            {
+              iob_free(iob);
+            }
+
+          iob_remove_queue(&conn->readahead);
+          return 0;
+        }
+
       DEBUGASSERT(iob->io_pktlen > 0);
 
 #ifdef CONFIG_NET_TIMESTAMP
@@ -253,31 +266,23 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
        * beginning of the I/O buffer chain.
        */
 
-      if (recvlen >= iob->io_pktlen)
-        {
-          FAR struct iob_s *tmp;
+      /* No trimming needed since one CAN/CANFD frame can perfectly
+       * fit in one iob
+       */
 
-          /* Remove the I/O buffer chain from the head of the read-ahead
-           * buffer queue.
-           */
+      FAR struct iob_s *tmp;
 
-          tmp = iob_remove_queue(&conn->readahead);
-          DEBUGASSERT(tmp == iob);
-          UNUSED(tmp);
+      /* Remove the I/O buffer chain from the head of the read-ahead
+       * buffer queue.
+       */
 
-          /* And free the I/O buffer chain */
+      tmp = iob_remove_queue(&conn->readahead);
+      DEBUGASSERT(tmp == iob);
+      UNUSED(tmp);
 
-          iob_free_chain(iob);
-        }
-      else
-        {
-          /* The bytes that we have received from the head of the I/O
-           * buffer chain (probably changing the head of the I/O
-           * buffer queue).
-           */
+      /* And free the I/O buffer chain */
 
-          iob_trimhead_queue(&conn->readahead, recvlen);
-        }
+      iob_free_chain(iob);
 
       /* do not pass frames with DLC > 8 to a legacy socket */
 #if defined(CONFIG_NET_CANPROTO_OPTIONS) && defined(CONFIG_NET_CAN_CANFD)

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -102,7 +102,12 @@ void devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
 
   /* Prepare device buffer before poll callback */
 
-  iob_update_pktlen(dev->d_iob, offset);
+  /* if pktlen is 0, no need to update */
+
+  if (offset != 0)
+    {
+      iob_update_pktlen(dev->d_iob, offset);
+    }
 
   ret = iob_trycopyin(dev->d_iob, buf, len, offset, false);
   if (ret != len)


### PR DESCRIPTION
## Summary
Fixes for iob semcount runaway problem.

## Impact
net/can and net/devif

## Testing
Saluki v2 UAVCAN flight
Flight now last indefinitely. Several test and no freeze so far.  iob semcount is kept in check
