### PR TITLE
arch/risc-v/src/mpfs: Make mpfs_hart_index2id table modifiable by boo…

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_entrypoints.c
+++ b/arch/risc-v/src/mpfs/mpfs_entrypoints.c
@@ -185,4 +185,28 @@ int mpfs_set_use_sbi(uint64_t hartid, bool use_sbi)
   return ERROR;
 }
 
+/****************************************************************************
+ * Name: mpfs_get_use_sbi
+ *
+ * Description:
+ *   Get if hart boots via SBI.
+ *
+ * Input Parameters:
+ *   hartid - hart id to check
+ *
+ * Returned value:
+ *   true if SBI is used, false otherwise
+ *
+ ****************************************************************************/
+
+bool mpfs_get_use_sbi(uint64_t hartid)
+{
+  if (hartid < ENTRYPT_CNT)
+    {
+      return (g_hart_use_sbi & (1 << hartid)) != 0;
+    }
+
+  return false;
+}
+
 #endif /* CONFIG_MPFS_BOOTLOADER */

--- a/arch/risc-v/src/mpfs/mpfs_entrypoints.h
+++ b/arch/risc-v/src/mpfs/mpfs_entrypoints.h
@@ -86,6 +86,22 @@ int mpfs_set_entrypt(uint64_t hartid, uintptr_t entry);
 
 int mpfs_set_use_sbi(uint64_t hartid, bool use_sbi);
 
+/****************************************************************************
+ * Name: mpfs_get_use_sbi
+ *
+ * Description:
+ *   Get if hart boots via SBI.
+ *
+ * Input Parameters:
+ *   hartid - hart id to check
+ *
+ * Returned value:
+ *   true if SBI is used, false otherwise
+ *
+ ****************************************************************************/
+
+bool mpfs_get_use_sbi(uint64_t hartid);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -185,30 +185,7 @@ static struct aclint_mswi_data mpfs_mswi =
  * Unused hart is marked with -1.  Mpfs will always have the hart0 unused.
  */
 
-static const u32 mpfs_hart_index2id[MPFS_HART_COUNT] =
-{
-  [0] = -1,
-#ifdef CONFIG_MPFS_HART1_SBI
-  [1] = 1,
-#else
-  [1] = -1,
-#endif
-#ifdef CONFIG_MPFS_HART2_SBI
-  [2] = 2,
-#else
-  [2] = -1,
-#endif
-#ifdef CONFIG_MPFS_HART3_SBI
-  [3] = 3,
-#else
-  [3] = -1,
-#endif
-#ifdef CONFIG_MPFS_HART4_SBI
-  [4] = 4,
-#else
-  [4] = -1,
-#endif
-};
+static u32 mpfs_hart_index2id[MPFS_HART_COUNT];
 
 static const struct sbi_platform platform =
 {
@@ -602,6 +579,13 @@ static int mpfs_opensbi_ecall_handler(long extid, long funcid,
 void __attribute__((noreturn)) mpfs_opensbi_setup(void)
 {
   uint32_t hartid = current_hartid();
+  size_t i;
+
+  for (i = 0; i < sizeof(mpfs_hart_index2id) / sizeof(mpfs_hart_index2id[0]);
+       i++)
+    {
+      mpfs_hart_index2id[i] = mpfs_get_use_sbi(i) ? i : -1;
+    }
 
   mpfs_opensbi_pmp_setup();
 


### PR DESCRIPTION
…tloader

This is actually the same table as entrypoints, so just use the same data, which can be set before booting any of the harts

## Summary

## Impact

## Testing

