### PR TITLE
[REVERTME] riscv/fpu: Save the FPU state always, if it has been used …

### DIFF
--- a/arch/risc-v/src/common/riscv_macros.S
+++ b/arch/risc-v/src/common/riscv_macros.S
@@ -105,7 +105,7 @@
   li         t1, MSTATUS_FS
   and        t2, t0, t1
   li         t1, MSTATUS_FS_DIRTY
-  bne        t2, t1, skip_save_fpu
+  blt        t2, t1, skip_save_fpu
   li         t1, ~MSTATUS_FS
   and        t0, t0, t1
   li         t1, MSTATUS_FS_CLEAN


### PR DESCRIPTION
…ever

Store the FPU registers always if it has been used, i.e. status is DIRTY or CLEAN (not OFF or INIT).

This should be reverted once the correct lazy-FPU operation has been restored.

