### PR TITLE
Revert "[REVERTME] arch/risc-v/src/mpfs/mpfs_corespi.c: Hack around a…

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corespi.c
+++ b/arch/risc-v/src/mpfs/mpfs_corespi.c
@@ -661,13 +661,7 @@ static int mpfs_spi_sem_waitdone(struct mpfs_spi_priv_s *priv)
 {
   uint32_t timeout = SPI_TTOA_US(priv->txwords * priv->nbits, priv->actual);
   timeout += SPI_TTOA_MARGIN_US;
-
-  /* Hack: add +1 to timeout due to some bug in NuttX. It randomly timeouts
-   * one tick too early
-   */
-
-  return nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout) +
-                                        1);
+  return nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout));
 }
 
 /****************************************************************************


### PR DESCRIPTION
… bug in nuttx nxsem_tickwait_uninterruptible bug"

This reverts commit c9a794c8290e314d4824d2f2c086f309b97d6fcf.

