### PR TITLE
Revert "opensbi: update to contain shrinked version"

### DIFF
--- a/arch/risc-v/src/opensbi/Make.defs
+++ b/arch/risc-v/src/opensbi/Make.defs
@@ -37,10 +37,10 @@ INCLUDES  += $(shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)opensbi$(DELIM)open
 SBI_DIR   := opensbi
 
 OPENSBI_UNPACK  = opensbi-3rdparty
-OPENSBI_COMMIT  = 5546c21701b21eaf6c8b0bff551e77b1a241d8ef
+OPENSBI_COMMIT  = b18bb7ce78d4e5504a9cbd8df7b57d795f489a0a
 OPENSBI_URL     = https://github.com/tiiuae/opensbi/tarball
 OPENSBI_TARBALL = opensbi.tar.gz
-OPENSBI_DIR     = tiiuae-opensbi-5546c21
+OPENSBI_DIR     = tiiuae-opensbi-b18bb7c
 
 $(OPENSBI_TARBALL):
 	$(call DOWNLOAD,$(OPENSBI_URL),$(OPENSBI_COMMIT),opensbi/$(OPENSBI_TARBALL))


### PR DESCRIPTION
This reverts commit 95e02b03068cbac3b88d8894fb82706d98d2fb71.

The commit doubled the OpenSBI envm size. Perhaps a mistake in the 42a8ece commit at the OpenSBI repo (somehow not getting the earlier commits that save space).

## Summary

## Impact

## Testing

