### PR TITLE
arch/risc-v/src/mpfs: Clean up BCLKSCLK training

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -157,11 +157,18 @@ config MPFS_DDR_TYPE
 	default 3 if MPFS_DDR_TYPE_LPDDR3
 	default 4 if MPFS_DDR_TYPE_LPDDR4
 
-config MPFS_DDR_MANUAL_ADDCMD_TRAINING
-	bool "Use manual addcmd training"
+config MPFS_DDR_MANUAL_BCLSCLK_TRAINING
+	bool "Use manual bclk/sclk training"
         default n
 	---help---
-		This adds code for manual addcmd training. To use it also enable bit 1 in TIP_CFG_PARAMS to skip the automatic one
+		This adds code for manual bclk/sclk training. To use it also enable bit 0 in LIBERO_SETTING_TRAINING_SKIP_SETTING to skip the automatic one
+
+config MPFS_DDR_MANUAL_ADDCMD_TRAINING
+	bool "Use manual addcmd training"
+	depends on DDR_MANUAL_BCLSCLK_TRAINING
+	default n
+	---help---
+		This adds code for manual addcmd training. To use it also enable bit 1 in LIBERO_SETTING_TRAINING_SKIP_SETTING to skip the automatic one
 
 config MPFS_ENABLE_CACHE
 	bool "Enable L2 cache"


### PR DESCRIPTION
## Summary

This makes it possible to remove manual bclksclk training in case the SOC internal one is wanted to be used only.

Note that the manual addcmd training depends on having manual bclksclk training, so this dependency is managed in Kconfig

## Impact

??

## Testing

Tried out on saluki-pi and saluki-v2, but not properly tested on several devices.
