### PR TITLE
risc-v/mpfs: Add DMA buffer allocator for eMMC access

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -391,6 +391,9 @@ config MPFS_EMMCSD
 	select ARCH_HAVE_SDIO
 	select SDIO_BLOCKSETUP
 	select SDIO_DMA
+	select FAT_DMAMEMORY
+	select FAT_FORCE_INDIRECT
+	select GRAN
 	default n
 	---help---
 		Selects the MPFS eMMCSD driver.

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -62,6 +62,10 @@ ifeq ($(CONFIG_MPFS_EMMCSD),y)
 CHIP_CSRCS += mpfs_emmcsd.c
 endif
 
+ifeq ($(CONFIG_FAT_DMAMEMORY),y)
+CHIP_CSRCS += mpfs_dma_alloc.c
+endif
+
 ifeq ($(CONFIG_MPFS_COREMMC),y)
 CHIP_CSRCS += mpfs_coremmc.c
 endif

--- a/arch/risc-v/src/mpfs/mpfs_dma_alloc.c
+++ b/arch/risc-v/src/mpfs/mpfs_dma_alloc.c
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_dma_alloc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <errno.h>
+#include <nuttx/mm/gran.h>
+
+#if defined(CONFIG_FAT_DMAMEMORY) && defined(CONFIG_GRAN)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BOARD_DMA_ALLOC_POOL_SIZE (8*512)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static GRAN_HANDLE dma_allocator;
+
+/* The DMA heap size constrains the total number of things that can be
+ * ready to do DMA at a time.
+ *
+ * For example, FAT DMA depends on one sector-sized buffer per filesystem
+ * plus one sector-sized buffer per file.
+ *
+ * We use a fundamental alignment / granule size of 64B; it fulfills the
+ * requirement for any DMA engine.
+ */
+
+static uint8_t g_dma_heap[BOARD_DMA_ALLOC_POOL_SIZE] aligned_data(64);
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mpfs_dma_alloc
+ *
+ * Description:
+ *   All boards may optionally provide this API to instantiate a pool of
+ *   memory for uses with FAST FS DMA operations.
+ *
+ ****************************************************************************/
+
+int mpfs_dma_alloc_init(void)
+{
+  /* Allocate 128B granules with 64B alignment */
+
+  dma_allocator = gran_initialize(g_dma_heap, sizeof(g_dma_heap), 7, 6);
+
+  if (dma_allocator == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  return OK;
+}
+
+void *fat_dma_alloc(size_t size)
+{
+  return gran_alloc(dma_allocator, size);
+}
+
+void fat_dma_free(void *memory, size_t size)
+{
+  gran_free(dma_allocator, memory, size);
+}
+
+#endif /* CONFIG_FAT_DMAMEMORY && CONFIG_GRAN */

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -122,6 +122,7 @@ int exec_module(FAR struct binary_s *binp,
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   FAR struct arch_addrenv_s *addrenv = &binp->addrenv->addrenv;
   FAR void *vheap;
+  char name[CONFIG_PATH_MAX];
 #endif
   FAR void *stackaddr = NULL;
   pid_t pid;
@@ -166,6 +167,14 @@ int exec_module(FAR struct binary_s *binp,
     }
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+  /* If there is no argument vector, the process name must be copied here */
+
+  if (argv == NULL)
+    {
+      strlcpy(name, filename, CONFIG_PATH_MAX);
+      filename = name;
+    }
+
   /* Instantiate the address environment containing the user heap */
 
   ret = addrenv_select(binp->addrenv, &binp->oldenv);


### PR DESCRIPTION
The MPFS eMMC DMA has some requirements that are only fulfilled by enabling separate DMA access buffers (FAT DMA buffers) and by forcing indirect access to the media via FAT_FORCE_INDIRECT.

Why? Direct access to user buffers violates two things:
- Buffer alignment is not ensured
- Buffers are user memory (problematic in BUILD_KERNEL)

Will also upstream this

