### PR TITLE
arch/risc-v/src/mpfs/mpfs_serial.c: Allow switching uart output to co…

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_serial.c
+++ b/arch/risc-v/src/mpfs/mpfs_serial.c
@@ -1355,6 +1355,13 @@ static void up_send(struct uart_dev_s *dev, int ch)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
 
+#ifdef HAVE_SERIAL_CONSOLE
+  if (dev == &CONSOLE_DEV && !dev->isconsole)
+    {
+      return;
+    }
+#endif
+
   while ((up_serialin(priv, MPFS_UART_LSR_OFFSET)
           & UART_LSR_THRE) == 0);
 
@@ -1547,6 +1554,12 @@ int up_putc(int ch)
 #ifdef HAVE_SERIAL_CONSOLE
   struct up_dev_s *priv = (struct up_dev_s *)CONSOLE_DEV.priv;
   uint32_t ier;
+
+  if (!CONSOLE_DEV.isconsole)
+    {
+      return ch;
+    }
+
   up_disableuartint(priv, &ier);
 #endif
 


### PR DESCRIPTION
…nsole off

By setting "isconsole" to false, mpfs_serial stops outputting to console.

This can be used to disable output to debug console in low level, e.g. disable NSH console without closing the device
