### PR TITLE
risc-v/mpfs: i2c: prevent corruption

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -492,7 +492,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
             /* Jump to the next message */
 
-            priv->msgid++;
+            if (priv->msgid < (priv->msgc - 1))
+              {
+                priv->msgid++;
+              }
           }
         else
           {
@@ -511,7 +514,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
                 /* Jump to the next message */
 
-                priv->msgid++;
+                if (priv->msgid < (priv->msgc - 1))
+                  {
+                    priv->msgid++;
+                  }
               }
             else
               {


### PR DESCRIPTION
priv->msgid may grow past its boundaries, causing
struct i2c_msg_s *msg = &priv->msgv[priv->msgid];
to eventually cause corruption.

## Summary

Fix a memory corruption issue

## Impact

At least all saluki devices

## Testing

Saluki v2