### PR TITLE
risc-v/mpfs: tamper: fix a typo

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_tamper.c
+++ b/arch/risc-v/src/mpfs/mpfs_tamper.c
@@ -241,7 +241,7 @@ static int mpfs_tamper_interrupt(int irq, void *context, void *arg)
   if (eventlist)
     {
       tinfo("**********************************************************\n");
-      tinfo("Tamper detection has caught out the following event(s):\n");
+      tinfo("Tamper detection has caught the following event(s):\n");
       for (i = 0; i < FLAG_BITS; i++)
         {
           if ((1 << i) & eventlist)


### PR DESCRIPTION
Caught off means something else that was intended.

## Summary

## Impact

## Testing

