### PR TITLE
net: rpmsgdrv.c: prevent potential danger

### DIFF
--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -594,6 +594,13 @@ static int net_rpmsg_drv_ept_cb(FAR struct rpmsg_endpoint *ept, void *data,
   FAR struct net_rpmsg_header_s *header = data;
   uint32_t command = header->command;
 
+#ifdef CONFIG_MPFS_IHC_CLIENT
+  if (command != NET_RPMSG_TRANSFER)
+    {
+      return -EINVAL;
+    }
+#endif
+
   if (command < sizeof(g_net_rpmsg_drv_handler) /
                 sizeof(g_net_rpmsg_drv_handler[0]))
     {


### PR DESCRIPTION
Provide support for NET_RPMSG_TRANSFER only:

"It is recommended to drop all messages with commands other than NET_RPMSG_TRANSFER in function net_rpmsg_drv_ept_cb() of the flight controller."

## Summary

As described in DP-7311

## Impact

## Testing

NuttX / AMP mode with Linux kernel / ping -A between NuttX and Linux