### PR TITLE
fix MPFS_ETHMAC_HPWORK flag

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -852,6 +852,20 @@ endchoice # GMAC speed
 
 endif # !MPFS_MAC_AUTONEG
 
+config MPFS_ETHMAC_HPWORK
+	bool "Use HP workqueue"
+	default n
+	depends on MPFS_ETHMAC
+	---help---
+		Select HPWORK workqueue for eth ISR work
+
+config MPFS_ETHMAC_LPWORK
+	bool "Use LP workqueue"
+	default n
+	depends on MPFS_ETHMAC
+	---help---
+		Select LPWORK workqueue for eth ISR work
+
 config MPFS_ETHMAC_MDC_CLOCK_SOURCE_HZ
 	int "MDC Clock Source (Hz)"
 	default 125000000

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -107,7 +107,7 @@
 #  elif defined(CONFIG_MPFS_ETHMAC_LPWORK)
 #    define ETHWORK LPWORK
 #  else
-#    define ETHWORK LPWORK
+#    define ETHWORK HPWORK
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary
MPFS_ETHMAC_HPWORK config is missing from mpfs Kconfig

## Impact
configuration can't be taken into use
