### PR TITLE
Upstream fixes

### DIFF
--- a/arch/risc-v/include/elf.h
+++ b/arch/risc-v/include/elf.h
@@ -83,4 +83,25 @@
 #define R_RISCV_SET32         56
 #define R_RISCV_32_PCREL      57
 
+#define ARCH_ELFDATA          1
+#define ARCH_ELF_RELCNT       8
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+struct arch_elfdata_s
+{
+  struct hi20_rels_s
+  {
+    uintptr_t hi20_rel;
+    uintptr_t hi20_offset;
+  }
+  hi20_rels[ARCH_ELF_RELCNT];
+};
+typedef struct arch_elfdata_s arch_elfdata_t;
+
+#endif /* __ASSEMBLY__ */
 #endif /* __ARCH_RISCV_INCLUDE_ELF_H */

--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -32,7 +32,6 @@
 #include <nuttx/compiler.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#include <nuttx/lib/math32.h>
 
 #include "riscv_internal.h"
 
@@ -90,6 +89,32 @@ typedef struct pmp_entry_s pmp_entry_t;
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: log2ceil
+ *
+ * Description:
+ *   Calculate the up-rounded power-of-two for input.
+ *
+ * Input Parameters:
+ *   x - Argument to calculate the power-of-two from.
+ *
+ * Returned Value:
+ *   Power-of-two for argument, rounded up.
+ *
+ ****************************************************************************/
+
+static uintptr_t log2ceil(uintptr_t x)
+{
+  uintptr_t pot = 0;
+
+  for (x = x - 1; x; x >>= 1)
+    {
+      pot++;
+    }
+
+  return pot;
+}
+
+/****************************************************************************
  * Name: pmp_check_region_attrs
  *
  * Description:
@@ -143,7 +168,7 @@ static bool pmp_check_region_attrs(uintptr_t base, uintptr_t size,
 
         /* Get the power-of-two for size, rounded up */
 
-        if ((base & ((UINT64_C(1) << LOG2_CEIL(size)) - 1)) != 0)
+        if ((base & ((UINT64_C(1) << log2ceil(size)) - 1)) != 0)
           {
             /* The start address is not properly aligned with size */
 

--- a/binfmt/libelf/libelf_bind.c
+++ b/binfmt/libelf/libelf_bind.c
@@ -55,6 +55,15 @@
 #  define elf_dumpbuffer(m,b,n)
 #endif
 
+#ifdef ARCH_ELFDATA
+#  define ARCH_ELFDATA_DEF  arch_elfdata_t arch_data; \
+                            memset(&arch_data, 0, sizeof(arch_elfdata_t))
+#  define ARCH_ELFDATA_PARM &arch_data
+#else
+#  define ARCH_ELFDATA_DEF
+#  define ARCH_ELFDATA_PARM NULL
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -184,6 +193,10 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx,
   int                   ret;
   int                   i;
   int                   j;
+
+  /* Define potential architecture specific elf data container */
+
+  ARCH_ELFDATA_DEF;
 
   rels = kmm_malloc(CONFIG_ELF_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rel));
   if (rels == NULL)
@@ -334,7 +347,7 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx,
 
       /* Now perform the architecture-specific relocation */
 
-      ret = up_relocate(rel, sym, addr);
+      ret = up_relocate(rel, sym, addr, ARCH_ELFDATA_PARM);
       if (ret < 0)
         {
           berr("ERROR: Section %d reloc %d: Relocation failed: %d\n",
@@ -369,6 +382,10 @@ static int elf_relocateadd(FAR struct elf_loadinfo_s *loadinfo, int relidx,
   int                   ret;
   int                   i;
   int                   j;
+
+  /* Define potential architecture specific elf data container */
+
+  ARCH_ELFDATA_DEF;
 
   relas = kmm_malloc(CONFIG_ELF_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rela));
   if (relas == NULL)
@@ -519,7 +536,7 @@ static int elf_relocateadd(FAR struct elf_loadinfo_s *loadinfo, int relidx,
 
       /* Now perform the architecture-specific relocation */
 
-      ret = up_relocateadd(rela, sym, addr);
+      ret = up_relocateadd(rela, sym, addr, ARCH_ELFDATA_PARM);
       if (ret < 0)
         {
           berr("ERROR: Section %d reloc %d: Relocation failed: %d\n",

--- a/include/nuttx/elf.h
+++ b/include/nuttx/elf.h
@@ -142,9 +142,9 @@ bool up_checkarch(FAR const Elf_Ehdr *hdr);
 
 #ifdef CONFIG_LIBC_ARCH_ELF
 int up_relocate(FAR const Elf_Rel *rel, FAR const Elf_Sym *sym,
-                uintptr_t addr);
-int up_relocateadd(FAR const Elf_Rela *rel,
-                   FAR const Elf_Sym *sym, uintptr_t addr);
+                uintptr_t addr, FAR void *arch_data);
+int up_relocateadd(FAR const Elf_Rela *rel, FAR const Elf_Sym *sym,
+                   uintptr_t addr, FAR void *arch_data);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
Pull two changes from upstream:
1. Decreases envm usage by ~3.5K
2. Allows usage of compiler optimized memcpy et al

Note: the second commit is stripped because libs/modlib has undergone way too many changes and would necessitate pulling
in dozens of commits to get this one in.
