### PR TITLE
PX4 debug disable 5/5

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corespi.c
+++ b/arch/risc-v/src/mpfs/mpfs_corespi.c
@@ -535,9 +535,9 @@ static uint32_t mpfs_spi_setfrequency(struct spi_dev_s *dev,
 
   priv->frequency = frequency;
 
-  /* Formula is SPICLK = PCLK/(2*(CFG_CLK + 1)) */
+  /* Formula is SPICLK = PCLK/(2*(CFG_CLK + 1)) (result is rounded up) */
 
-  divider = ((MPFS_FPGA_PERIPHERAL_CLK / frequency) >> 1) - 1;
+  divider = (MPFS_FPGA_PERIPHERAL_CLK / frequency) >> 1;
   priv->actual = MPFS_FPGA_PERIPHERAL_CLK / ((divider + 1) << 1);
 
   DEBUGASSERT(divider < 256u);

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -492,7 +492,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
             /* Jump to the next message */
 
-            priv->msgid++;
+            if (priv->msgid < (priv->msgc - 1))
+              {
+                priv->msgid++;
+              }
           }
         else
           {
@@ -511,7 +514,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
                 /* Jump to the next message */
 
-                priv->msgid++;
+                if (priv->msgid < (priv->msgc - 1))
+                  {
+                    priv->msgid++;
+                  }
               }
             else
               {

--- a/arch/risc-v/src/mpfs/mpfs_serial.c
+++ b/arch/risc-v/src/mpfs/mpfs_serial.c
@@ -1355,6 +1355,13 @@ static void up_send(struct uart_dev_s *dev, int ch)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
 
+#ifdef HAVE_SERIAL_CONSOLE
+  if (dev == &CONSOLE_DEV && !dev->isconsole)
+    {
+      return;
+    }
+#endif
+
   while ((up_serialin(priv, MPFS_UART_LSR_OFFSET)
           & UART_LSR_THRE) == 0);
 
@@ -1547,6 +1554,12 @@ int up_putc(int ch)
 #ifdef HAVE_SERIAL_CONSOLE
   struct up_dev_s *priv = (struct up_dev_s *)CONSOLE_DEV.priv;
   uint32_t ier;
+
+  if (!CONSOLE_DEV.isconsole)
+    {
+      return ch;
+    }
+
   up_disableuartint(priv, &ier);
 #endif
 


### PR DESCRIPTION
Backporting PX4 debug disable features from mainline.

Parent PRs:
https://github.com/tiiuae/px4-firmware-fc-only/pull/49