### PR TITLE
[HACK] cstdlib: Forward malloc et. al. to kmm_malloc, if __KERNEL__

### DIFF
--- a/include/cxx/cstdlib
+++ b/include/cxx/cstdlib
@@ -28,6 +28,28 @@
 #include <nuttx/config.h>
 #include <stdlib.h>
 
+#include <nuttx/lib/lib.h>
+
+//***************************************************************************
+// Pre-processor Definitions
+//***************************************************************************
+
+#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
+#undef malloc
+#undef free
+#undef realloc
+#undef memalign
+#undef zalloc
+#undef calloc
+
+#define malloc   kmm_malloc
+#define free     kmm_free
+#define realloc  kmm_realloc
+#define memalign kmm_memalign
+#define zalloc   kmm_zalloc
+#define calloc   kmm_calloc
+#endif
+
 //***************************************************************************
 // Namespace
 //***************************************************************************


### PR DESCRIPTION
This is the only way to get the external module "uavcanlib" to work inside the px4 kernel.

If an alternate solution, e.g. moving uavcanlib to user space is implemented this hack should be removed.

[NOT UPSTREAMABLE]

