### PR TITLE
wrapper to support multiple sdio device drivers

### DIFF
--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -58,6 +58,10 @@ ifeq ($(CONFIG_I2C),y)
 CHIP_CSRCS += mpfs_i2c.c
 endif
 
+ifneq ($(filter y,$(CONFIG_MPFS_EMMCSD) $(CONFIG_MPFS_COREMMC)),)
+CHIP_CSRCS += mpfs_sdio.c
+endif
+
 ifeq ($(CONFIG_MPFS_EMMCSD),y)
 CHIP_CSRCS += mpfs_emmcsd.c
 endif

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.h
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.h
@@ -48,7 +48,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: sdio_initialize
+ * Name: mpfs_coremmc_sdio_initialize
  *
  * Description:
  *   Initialize SDIO for operation.
@@ -63,10 +63,10 @@ extern "C"
  ****************************************************************************/
 
 struct sdio_dev_s; /* See include/nuttx/sdio.h */
-struct sdio_dev_s *sdio_initialize(int slotno);
+struct sdio_dev_s *mpfs_coremmc_sdio_initialize(int slotno);
 
 /****************************************************************************
- * Name: sdio_mediachange
+ * Name: mpfs_coremmc_sdio_mediachange
  *
  * Description:
  *   Called by board-specific logic -- possibly from an interrupt handler --
@@ -84,10 +84,10 @@ struct sdio_dev_s *sdio_initialize(int slotno);
  *
  ****************************************************************************/
 
-void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
+void mpfs_coremmc_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
 
 /****************************************************************************
- * Name: sdio_wrprotect
+ * Name: mpfs_coremmc_sdio_wrprotect
  *
  * Description:
  *   Called by board-specific logic to report if the card in the slot is
@@ -102,7 +102,7 @@ void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
  *
  ****************************************************************************/
 
-void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
+void mpfs_coremmc_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -50,6 +50,8 @@
 #include "hardware/mpfs_emmcsd.h"
 #include "hardware/mpfs_mpucfg.h"
 
+#include "mpfs_sdio_dev.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -290,58 +292,6 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
-
-/* This structure defines the state of the MPFS eMMCSD interface */
-
-struct mpfs_dev_s
-{
-  struct sdio_dev_s  dev;             /* Standard, base SDIO interface */
-
-  const uintptr_t    hw_base;         /* Base address */
-  const int          plic_irq;        /* PLIC interrupt */
-  bool               clk_enabled;     /* Clk state */
-
-  /* eMMC / SD and HW parameters */
-
-  const bool         emmc;            /* eMMC or SD */
-  int                bus_voltage;     /* Bus voltage */
-  int                bus_mode;        /* eMMC Bus mode */
-  bool               jumpers_3v3;     /* Jumper settings: 1v8 or 3v3 */
-
-  /* Event support */
-
-  sem_t              waitsem;         /* Implements event waiting */
-  sdio_eventset_t    waitevents;      /* Set of events to be waited for */
-  uint32_t           waitmask;        /* Interrupt enables for event waiting */
-  volatile sdio_eventset_t wkupevent; /* The event that caused the wakeup */
-  struct wdog_s      waitwdog;        /* Watchdog that handles event timeouts */
-
-  /* Callback support */
-
-  sdio_statset_t     cdstatus;        /* Card status */
-  sdio_eventset_t    cbevents;        /* Set of events to be cause callbacks */
-  worker_t           callback;        /* Registered callback function */
-  void              *cbarg;           /* Registered callback argument */
-  struct work_s      cbwork;          /* Callback work queue structure */
-
-  /* Interrupt mode data transfer support */
-
-  uint32_t          *buffer;          /* Address of current R/W buffer */
-  size_t             remaining;       /* Number of bytes remaining in the transfer */
-  size_t             receivecnt;      /* Real count to receive */
-  uint32_t           xfrmask;         /* Interrupt enables for data transfer */
-
-  bool               widebus;         /* Required for DMA support */
-  bool               onebit;          /* true: Only 1-bit transfers are supported */
-
-  /* DMA data transfer support */
-
-  bool               polltransfer;    /* Indicate a poll transfer, no DMA */
-
-  /* Misc */
-
-  uint32_t           blocksize;       /* Current block size */
-};
 
 /****************************************************************************
  * Private Function Prototypes
@@ -1145,14 +1095,14 @@ static int mpfs_emmcsd_interrupt(int irq, void *context, void *arg)
         {
           mcinfo("Card inserted!\n");
 
-          sdio_mediachange((struct sdio_dev_s *)priv, true);
+          mpfs_emmcsd_sdio_mediachange((struct sdio_dev_s *)priv, true);
           putreg32(MPFS_EMMCSD_SRS12_CIN, MPFS_EMMCSD_SRS12);
         }
       else if (status & MPFS_EMMCSD_SRS12_CR)
         {
           mcinfo("Card removed!\n");
 
-          sdio_mediachange((struct sdio_dev_s *)priv, false);
+          mpfs_emmcsd_sdio_mediachange((struct sdio_dev_s *)priv, false);
           putreg32(MPFS_EMMCSD_SRS12_CR, MPFS_EMMCSD_SRS12);
         }
       else
@@ -3043,7 +2993,7 @@ static void mpfs_callback(void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sdio_initialize
+ * Name: mpfs_emmcsd_sdio_initialize
  *
  * Description:
  *   Initialize SDIO for operation.
@@ -3057,7 +3007,7 @@ static void mpfs_callback(void *arg)
  *
  ****************************************************************************/
 
-struct sdio_dev_s *sdio_initialize(int slotno)
+struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno)
 {
   struct mpfs_dev_s *priv = NULL;
   priv = &g_emmcsd_dev;
@@ -3068,14 +3018,14 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   if (!mpfs_device_reset(&priv->dev))
     {
-      return NULL;
+      return (struct sdio_dev_s *)NULL;
     }
 
-  return &priv->dev;
+  return (struct sdio_dev_s *) &priv->dev;
 }
 
 /****************************************************************************
- * Name: sdio_mediachange
+ * Name: mpfs_emmcsd_sdio_mediachange
  *
  * Description:
  *   Called by board-specific logic -- possible from an interrupt handler --
@@ -3093,7 +3043,7 @@ struct sdio_dev_s *sdio_initialize(int slotno)
  *
  ****************************************************************************/
 
-void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
+void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   sdio_statset_t cdstatus;
@@ -3126,7 +3076,7 @@ void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
 }
 
 /****************************************************************************
- * Name: sdio_wrprotect
+ * Name: mpfs_emmcsd_sdio_wrprotect
  *
  * Description:
  *   Called by board-specific logic to report if the card in the slot is
@@ -3141,7 +3091,7 @@ void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
  *
  ****************************************************************************/
 
-void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
+void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   irqstate_t flags;

--- a/arch/risc-v/src/mpfs/mpfs_sdio.c
+++ b/arch/risc-v/src/mpfs/mpfs_sdio.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/mpfs/mpfs_emmcsd.h
+ * arch/risc-v/src/mpfs/mpfs_sdio.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,37 +18,32 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H
-#define __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <sys/types.h>
-#include <stdbool.h>
 
-#include "chip.h"
-#include "hardware/mpfs_emmcsd.h"
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <string.h>
+#include <arch/board/board.h>
+
+#include "mpfs_coremmc.h"
+#include "mpfs_emmcsd.h"
+#include "mpfs_sdio_dev.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-#ifndef __ASSEMBLY__
-
-#undef EXTERN
-#if defined(__cplusplus)
-#define EXTERN extern "C"
-extern "C"
-{
-#else
-#define EXTERN extern
-#endif
-
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_initialize
+ * Name: sdio_initialize
  *
  * Description:
  *   Initialize SDIO for operation.
@@ -62,16 +57,35 @@ extern "C"
  *
  ****************************************************************************/
 
-struct sdio_dev_s; /* See include/nuttx/sdio.h */
-struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno);
+struct sdio_dev_s *sdio_initialize(int slotno)
+{
+  switch (slotno)
+    {
+    case 0:
+#ifdef CONFIG_MPFS_EMMCSD
+      return mpfs_emmcsd_sdio_initialize(slotno);
+#endif
+
+    case 1:
+#ifdef CONFIG_MPFS_COREMMC
+      return mpfs_coremmc_sdio_initialize(slotno);
+#endif
+
+    default:
+      break;
+    }
+
+  mcerr("sdio slot number %d not supported!\n", slotno);
+  return NULL;
+}
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_mediachange
+ * Name: sdio_mediachange
  *
  * Description:
- *   Called by board-specific logic -- possibly from an interrupt handler --
+ *   Called by board-specific logic -- possible from an interrupt handler --
  *   in order to signal to the driver that a card has been inserted or
- *   removed from the slot.
+ *   removed from the slot
  *
  * Input Parameters:
  *   dev        - An instance of the SDIO driver device state structure.
@@ -79,15 +93,44 @@ struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno);
  *                card has been removed from the slot.  Only transitions
  *                (inserted->removed or removed->inserted should be reported)
  *
- * Returned Values:
+ * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
+void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
+{
+  struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
+
+  if (!dev)
+    {
+      mcerr("sdio device not found\n");
+      return;
+    }
+
+  switch (priv->hw_base)
+    {
+#ifdef CONFIG_MPFS_EMMCSD
+    case MPFS_EMMC_SD_BASE:
+      mpfs_emmcsd_sdio_mediachange(dev, cardinslot);
+      return;
+#endif
+
+#ifdef CONFIG_MPFS_COREMMC
+    case CONFIG_MPFS_COREMMC_BASE:
+      mpfs_coremmc_sdio_mediachange(dev, cardinslot);
+      return;
+#endif
+
+    default:
+      break;
+    }
+
+  mcerr("Invalid sdio base address\n");
+}
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_wrprotect
+ * Name: sdio_wrprotect
  *
  * Description:
  *   Called by board-specific logic to report if the card in the slot is
@@ -97,17 +140,38 @@ void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
  *   dev       - An instance of the SDIO driver device state structure.
  *   wrprotect - true is a card is writeprotected.
  *
- * Returned Values:
+ * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
+void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
+{
+  struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
 
-#undef EXTERN
-#if defined(__cplusplus)
-}
+  if (!dev)
+    {
+      mcerr("sdio device not found\n");
+      return;
+    }
+
+  switch (priv->hw_base)
+    {
+#ifdef CONFIG_MPFS_EMMCSD
+    case MPFS_EMMC_SD_BASE:
+      mpfs_emmcsd_sdio_wrprotect(dev, wrprotect);
+      return;
 #endif
 
-#endif /* __ASSEMBLY__ */
-#endif /* __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H */
+#ifdef CONFIG_MPFS_COREMMC
+    case CONFIG_MPFS_COREMMC_BASE:
+      mpfs_coremmc_sdio_wrprotect(dev, wrprotect);
+      return;
+#endif
+
+    default:
+      break;
+    }
+
+  mcerr("Invalid sdio base address\n");
+}

--- a/arch/risc-v/src/mpfs/mpfs_sdio.h
+++ b/arch/risc-v/src/mpfs/mpfs_sdio.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/mpfs/mpfs_emmcsd.h
+ * arch/risc-v/src/mpfs/mpfs_sdio.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,19 +18,18 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H
-#define __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H
+#ifndef __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_H
+#define __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <sys/types.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
 #include "chip.h"
-#include "hardware/mpfs_emmcsd.h"
 
 /****************************************************************************
  * Public Function Prototypes
@@ -48,7 +47,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_initialize
+ * Name: sdio_initialize
  *
  * Description:
  *   Initialize SDIO for operation.
@@ -63,10 +62,10 @@ extern "C"
  ****************************************************************************/
 
 struct sdio_dev_s; /* See include/nuttx/sdio.h */
-struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno);
+struct sdio_dev_s *sdio_initialize(int slotno);
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_mediachange
+ * Name: sdio_mediachange
  *
  * Description:
  *   Called by board-specific logic -- possibly from an interrupt handler --
@@ -84,10 +83,10 @@ struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno);
  *
  ****************************************************************************/
 
-void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
+void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_wrprotect
+ * Name: sdio_wrprotect
  *
  * Description:
  *   Called by board-specific logic to report if the card in the slot is
@@ -102,7 +101,7 @@ void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
  *
  ****************************************************************************/
 
-void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
+void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
 
 #undef EXTERN
 #if defined(__cplusplus)
@@ -110,4 +109,4 @@ void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
 #endif
 
 #endif /* __ASSEMBLY__ */
-#endif /* __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H */
+#endif /* __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_H */

--- a/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
+++ b/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_sdio_dev.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_DEV_H
+#define __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_DEV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/sdio.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This structure defines the state of the MPFS eMMCSD interface */
+
+struct mpfs_dev_s
+{
+  struct sdio_dev_s dev; /* Standard, base SDIO interface */
+
+  const uintptr_t hw_base; /* Base address */
+  const int plic_irq;      /* PLIC interrupt */
+  bool clk_enabled;        /* Clk state */
+
+  /* eMMC / SD and HW parameters */
+
+  const bool emmc;  /* eMMC or SD */
+  int bus_voltage;  /* Bus voltage */
+  int bus_mode;     /* eMMC Bus mode */
+  bool jumpers_3v3; /* Jumper settings: 1v8 or 3v3 */
+
+  /* Event support */
+
+  sem_t waitsem;                      /* Implements event waiting */
+  sdio_eventset_t waitevents;         /* Set of events to be waited for */
+  uint32_t waitmask;                  /* Interrupt enables for event waiting */
+  volatile sdio_eventset_t wkupevent; /* The event that caused the wakeup */
+  struct wdog_s waitwdog;             /* Watchdog that handles event timeouts */
+
+  /* Callback support */
+
+  sdio_statset_t cdstatus;  /* Card status */
+  sdio_eventset_t cbevents; /* Set of events to be cause callbacks */
+  worker_t callback;        /* Registered callback function */
+  void *cbarg;              /* Registered callback argument */
+  struct work_s cbwork;     /* Callback work queue structure */
+
+  /* Interrupt mode data transfer support */
+
+  uint32_t *buffer;     /* Address of current R/W buffer */
+  size_t remaining;     /* Number of bytes remaining in the transfer */
+  size_t receivecnt;    /* Real count to receive */
+  uint32_t xfrmask;     /* Interrupt enables for data transfer */
+  uint32_t xfr_blkmask; /* Interrupt enables for SB/MB data transfer */
+
+  bool widebus; /* Required for DMA support */
+  bool onebit;  /* true: Only 1-bit transfers are supported */
+
+  /* DMA data transfer support */
+
+  bool polltransfer; /* Indicate a poll transfer, no DMA */
+  bool multiblock;   /* Indicate a multi-block transfer */
+
+  /* Misc */
+
+  uint32_t blocksize;  /* Current block size */
+  uint32_t fifo_depth; /* Fifo size, read from the register */
+};
+
+#endif /* __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_DEV_H */

--- a/boards/risc-v/mpfs/common/src/mpfs_emmcsd.c
+++ b/boards/risc-v/mpfs/common/src/mpfs_emmcsd.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <nuttx/mmcsd.h>
 
-#include "mpfs_emmcsd.h"
+#include "mpfs_sdio.h"
 #include "board_config.h"
 
 /****************************************************************************


### PR DESCRIPTION
sdio device wrapper to support both mpfs_emmcsd and mpfs_coremmc drivers simultaneously

```
board_init ---> sdio_dev ---+----> mpfs_coremmc
                            |
                            +----> mpfs_emmcsd

```
