### PR TITLE
arch/arm/src/imxrt/imxrt_start.c: Clear CONTROL register at start to …

### DIFF
--- a/arch/arm/src/imxrt/imxrt_start.c
+++ b/arch/arm/src/imxrt/imxrt_start.c
@@ -149,10 +149,15 @@ void __start(void)
   const register uint32_t *src;
   register uint32_t *dest;
 
-  /* Make sure that interrupts are disabled and set SP */
+  /* Make sure that interrupts are disabled and set MSP */
 
   __asm__ __volatile__ ("\tcpsid  i\n");
   __asm__ __volatile__ ("MSR MSP, %0\n" : : "r" (IDLE_STACK) :);
+
+  /* Make sure that we use MSP from now on */
+
+  __asm__ __volatile__ ("MSR CONTROL, %0\n" : : "r" (0) :);
+  __asm__ __volatile__ ("ISB SY\n");
 
   /* Make sure VECTAB is set to NuttX vector table
    * and not the one from the boot ROM and have consistency


### PR DESCRIPTION
…make sure we use MSP as the stack pointer

When entering the function from an external bootloader, the CPU could be using PSP. But the following code expects MSP to be in use.

## Summary

Fixes booting to PX4 from px4 bootloader


