### PR TITLE
Fix socket can race condition

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_fpga_canfd.c
+++ b/arch/risc-v/src/mpfs/mpfs_fpga_canfd.c
@@ -701,6 +701,12 @@ static void mpfs_receive_work(void *arg)
 
       mpfs_can_retrieve_rx_frame(priv, cf, ffw);
 
+      /* Lock the network; we have to protect the dev.d_len, dev.d_buf
+       * and dev.d_iob from the devif_poll path
+       */
+
+      net_lock();
+
       /* Copy the buffer pointer to priv->dev..  Set amount of data
        * in priv->dev.d_len
        */
@@ -713,6 +719,8 @@ static void mpfs_receive_work(void *arg)
 
       NETDEV_RXPACKETS(&priv->dev);
       can_input(&priv->dev);
+
+      net_unlock();
 
       /* Point the packet buffer back to the next Tx buffer that will be
        * used during the next write.  If the write queue is full, then

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -214,11 +214,16 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
       can_readahead_signal(conn);
 #endif
       ret = iob->io_pktlen;
+
+      /* Device buffer has been enqueued, clear the handle */
+
+      netdev_iob_clear(dev);
     }
-
-  /* Device buffer must be enqueue or freed, clear the handle */
-
-  netdev_iob_clear(dev);
+  else
+    {
+      nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
+      netdev_iob_release(dev);
+    }
 
   return ret;
 }

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -62,9 +62,6 @@ can_data_event(FAR struct net_driver_s *dev, FAR struct can_conn_s *conn,
                uint16_t flags)
 {
   int buflen = dev->d_len;
-#ifdef CONFIG_NET_TIMESTAMP
-  buflen -= sizeof(struct timeval);
-#endif
   uint16_t recvlen;
   uint16_t ret;
 
@@ -136,19 +133,6 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
 
       if ((flags & CAN_NEWDATA) != 0)
         {
-          if (dev->d_iob->io_flink != NULL ||
-              dev->d_iob->io_pktlen == 0 ||
-              dev->d_iob->io_offset <= 0)
-            {
-              if (dev->d_iob->io_flink == NULL)
-                {
-                  iob_free(dev->d_iob);
-                }
-
-              netdev_iob_clear(dev);
-              return flags;
-            }
-
 #ifdef CONFIG_NET_TIMESTAMP
           /* TIMESTAMP sockopt is activated,
            * create timestamp and copy to iob

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -65,6 +65,10 @@ can_data_event(FAR struct net_driver_s *dev, FAR struct can_conn_s *conn,
   uint16_t recvlen;
   uint16_t ret;
 
+#ifdef CONFIG_NET_TIMESTAMP
+  buflen -= sizeof(struct timeval);
+#endif
+
   ret = (flags & ~CAN_NEWDATA);
 
   /* Save as the packet data as in the read-ahead buffer.  NOTE that

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -277,37 +277,26 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
       recvlen = iob_copyout(pstate->pr_buffer, iob, pstate->pr_buflen, 0);
 
-      /* If we took all of the data from the I/O buffer chain is empty, then
-       * release it.  If there is still data available in the I/O buffer
-       * chain, then just trim the data that we have taken from the
-       * beginning of the I/O buffer chain.
+      /* We should have taken all of the data from the I/O buffer chain,
+       * so release it. There is no trimming needed, since One CAN/CANFD
+       * frame can always fit in one IOB.
        */
 
-      if (recvlen >= iob->io_pktlen)
-        {
-          FAR struct iob_s *tmp;
+      static_assert(sizeof(struct can_frame) <= CONFIG_IOB_BUFSIZE);
 
-          /* Remove the I/O buffer chain from the head of the read-ahead
-           * buffer queue.
-           */
+      FAR struct iob_s *tmp;
 
-          tmp = iob_remove_queue(&conn->readahead);
-          DEBUGASSERT(tmp == iob);
-          UNUSED(tmp);
+      /* Remove the I/O buffer chain from the head of the read-ahead
+       * buffer queue.
+       */
 
-          /* And free the I/O buffer chain */
+      tmp = iob_remove_queue(&conn->readahead);
+      DEBUGASSERT(tmp == iob);
+      UNUSED(tmp);
 
-          iob_free_chain(iob);
-        }
-      else
-        {
-          /* The bytes that we have received from the head of the I/O
-           * buffer chain (probably changing the head of the I/O
-           * buffer queue).
-           */
+      /* And free the I/O buffer chain */
 
-          iob_trimhead_queue(&conn->readahead, recvlen);
-        }
+      iob_free_chain(iob);
 
       /* do not pass frames with DLC > 8 to a legacy socket */
 #if defined(CONFIG_NET_CANPROTO_OPTIONS) && defined(CONFIG_NET_CAN_CANFD)

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -233,7 +233,7 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
   pstate->pr_recvlen = -1;
 
-  if ((iob = iob_peek_queue(&conn->readahead)) != NULL &&
+  if ((iob = iob_remove_queue(&conn->readahead)) != NULL &&
       pstate->pr_buflen > 0)
     {
       DEBUGASSERT(iob->io_pktlen > 0);
@@ -246,17 +246,7 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
       if (can_recv_filter(conn, can_id) == 0)
         {
-          FAR struct iob_s *tmp;
-
-          /* Remove the I/O buffer chain from the head of the read-ahead
-           * buffer queue.
-           */
-
-          tmp = iob_remove_queue(&conn->readahead);
-          DEBUGASSERT(tmp == iob);
-          UNUSED(tmp);
-
-          /* And free the I/O buffer chain */
+          /* Free the I/O buffer chain */
 
           iob_free_chain(iob);
           return 0;
@@ -284,17 +274,7 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
       static_assert(sizeof(struct can_frame) <= CONFIG_IOB_BUFSIZE);
 
-      FAR struct iob_s *tmp;
-
-      /* Remove the I/O buffer chain from the head of the read-ahead
-       * buffer queue.
-       */
-
-      tmp = iob_remove_queue(&conn->readahead);
-      DEBUGASSERT(tmp == iob);
-      UNUSED(tmp);
-
-      /* And free the I/O buffer chain */
+      /* Free the I/O buffer chain */
 
       iob_free_chain(iob);
 

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -102,12 +102,7 @@ int devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
 
   /* Prepare device buffer before poll callback */
 
-  /* if pktlen is 0, no need to update */
-
-  if (offset != 0)
-    {
-      iob_update_pktlen(dev->d_iob, offset, false);
-    }
+  iob_update_pktlen(dev->d_iob, offset, false);
 
   ret = iob_trycopyin(dev->d_iob, buf, len, offset, false);
   if (ret != len)

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -102,7 +102,12 @@ int devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
 
   /* Prepare device buffer before poll callback */
 
-  iob_update_pktlen(dev->d_iob, offset, false);
+  /* if pktlen is 0, no need to update */
+
+  if (offset != 0)
+    {
+      iob_update_pktlen(dev->d_iob, offset, false);
+    }
 
   ret = iob_trycopyin(dev->d_iob, buf, len, offset, false);
   if (ret != len)


### PR DESCRIPTION
## Summary

This fixes the https://ssrc.atlassian.net/browse/DP-8022

The cause for the crash seems to be IOB chain corruption, which is caused by insufficient locking in the can / network stack.

The same locking issue is actually the root cause for the earlier "semcount runaway issue". Therefor, I have reverted the earlier fix for the semcount runaway issue.

The locking is added in patch "arch/risc-v/src/mpfs/mpfs_fpga_canfd.c: Fix a race condition with devif_poll"

Since the reverted patch contained also other things, I created separate patches for those. @haitomatic could you please check that those are correct; I preserved you as the "author" for those.

This PR also contains the following changes, which are not directly causing the issue, but are related:
"net/can: Release IOB when failed to queue in datahandler" <- this is a cherry pick from upstream
"net/can/can_recvmsg.c: Cleanup can_readahead" <- this just removes useless code and improves atomicity of can_readahead

## Impact

Fix random crashes when using uavcan on Saluki

## Testing

On-desk trials with a drone using can escs