### PR TITLE
Fix user task exit by exception

### DIFF
--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -31,6 +31,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 
+#include "sched/sched.h"
 #include "riscv_internal.h"
 #include "chip.h"
 
@@ -72,6 +73,9 @@ static const char *g_reasons_str[RISCV_MAX_EXCEPTION + 1] =
 
 int riscv_exception(int mcause, void *regs, void *args)
 {
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  FAR struct tcb_s *tcb = this_task();
+#endif
   uintptr_t cause = mcause & RISCV_IRQ_MASK;
 
   _alert("EXCEPTION: %s. MCAUSE: %" PRIxREG ", EPC: %" PRIxREG
@@ -79,10 +83,33 @@ int riscv_exception(int mcause, void *regs, void *args)
          mcause > RISCV_MAX_EXCEPTION ? "Unknown" : g_reasons_str[cause],
          cause, READ_CSR(CSR_EPC), READ_CSR(CSR_TVAL));
 
-  _alert("PANIC!!! Exception = %" PRIxREG "\n", cause);
-  up_irq_save();
-  CURRENT_REGS = regs;
-  PANIC_WITH_REGS("panic", regs);
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
+    {
+      _alert("Segmentation fault in PID %d: %s\n", tcb->pid, tcb->name);
+
+      tcb->flags |= TCB_FLAG_FORCED_CANCEL;
+
+      /* Return to _exit function in privileged mode with argument SIGSEGV */
+
+      CURRENT_REGS[REG_EPC] = (uintptr_t)_exit;
+      CURRENT_REGS[REG_A0] = SIGSEGV;
+      CURRENT_REGS[REG_INT_CTX] |= STATUS_PPP;
+
+      /* Continue with kernel stack in use. The frame(s) in kernel stack
+       * are no longer needed, so just set it to top
+       */
+
+      CURRENT_REGS[REG_SP] = (uintptr_t)tcb->xcp.ktopstk;
+    }
+  else
+#endif
+    {
+      _alert("PANIC!!! Exception = %" PRIxREG "\n", cause);
+      up_irq_save();
+      CURRENT_REGS = regs;
+      PANIC_WITH_REGS("panic", regs);
+    }
 
   return 0;
 }

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -28,6 +28,7 @@
 
 #include <nuttx/addrenv.h>
 
+#include "sched/sched.h"
 #include "riscv_internal.h"
 
 /****************************************************************************
@@ -59,6 +60,12 @@ void *riscv_perform_syscall(uintptr_t *regs)
 
   if (regs != CURRENT_REGS)
     {
+      /* Record the new "running" task.  g_running_tasks[] is only used by
+       * assertion logic for reporting crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+
       /* Restore the cpu lock */
 
       restore_critical_section();

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -181,29 +181,33 @@ int group_kill_children(FAR struct tcb_s *tcb)
 
 #if defined(CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS) && \
             CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS != 0
-  /* Send SIGTERM for each first */
 
-  group_foreachchild(tcb->group, group_kill_children_handler,
-                     (FAR void *)((uintptr_t)tcb->pid));
-
-  /* Wait a bit for child exit */
-
-  ret = CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS;
-  while (1)
+  if ((tcb->flags & TCB_FLAG_FORCED_CANCEL) == 0)
     {
-      if (tcb->group->tg_nmembers <= 1)
-        {
-          break;
-        }
+      /* Send SIGTERM for each first */
 
-      nxsig_usleep(USEC_PER_MSEC);
+      group_foreachchild(tcb->group, group_kill_children_handler,
+                         (FAR void *)((uintptr_t)tcb->pid));
+
+      /* Wait a bit for child exit */
+
+      ret = CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS;
+      while (1)
+        {
+          if (tcb->group->tg_nmembers <= 1)
+            {
+              break;
+            }
+
+          nxsig_usleep(USEC_PER_MSEC);
 
 #  if CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS > 0
-      if (--ret < 0)
-        {
-          break;
-        }
+          if (--ret < 0)
+            {
+              break;
+            }
 #  endif
+        }
     }
 #endif
 


### PR DESCRIPTION
## Summary

Fix the bugs DP-2143, DP-8522

I will still offer this to upstream review first

## Impact

Increase resilience to SW bugs, don't crash the whole system if a userspace process excepts

## Testing

Injected NULL dereference bugs in couple of PX4 processes, tried out that they exit without causing a panic.
