### PR TITLE
[BACKPORT] arm64_head.S: Add explicit input section for __start

### DIFF
--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -89,6 +89,8 @@ label:  .asciz msg;                             \
      * This must be the very first address in the loaded image.
      * It should be loaded at any 4K-aligned address.
      */
+
+    .section .start, "ax"
     .globl __start;
 __start:
 

--- a/boards/arm64/a64/pinephone/scripts/dramboot.ld
+++ b/boards/arm64/a64/pinephone/scripts/dramboot.ld
@@ -33,6 +33,7 @@ SECTIONS
   _start = .;
   .text : {
         _stext = .;            /* Text section */
+       *(.start .start.*)      /* Place __start here */
        *(.text)
        *(.text.cold)
        *(.text.unlikely)

--- a/boards/arm64/fvp-v8r/fvp-armv8r/scripts/dramboot.ld
+++ b/boards/arm64/fvp-v8r/fvp-armv8r/scripts/dramboot.ld
@@ -33,6 +33,7 @@ SECTIONS
   _start = .;
   .text : {
         _stext = .;            /* Text section */
+       *(.start .start.*)      /* Place __start here */
        *(.text)
        *(.text.cold)
        *(.text.unlikely)

--- a/boards/arm64/imx8/imx8qm-mek/scripts/dramboot.ld
+++ b/boards/arm64/imx8/imx8qm-mek/scripts/dramboot.ld
@@ -33,6 +33,7 @@ SECTIONS
   _start = .;
   .text : {
         _stext = .;            /* Text section */
+       *(.start .start.*)      /* Place __start here */
        *(.text)
        *(.text.cold)
        *(.text.unlikely)

--- a/boards/arm64/imx9/imx93-evk/scripts/dramboot.ld
+++ b/boards/arm64/imx9/imx93-evk/scripts/dramboot.ld
@@ -50,7 +50,7 @@ SECTIONS
   .text  :
     {
       _stext = ABSOLUTE(.);  /* Text section */
-      *(.text.__start)       /* Place __start here */
+      *(.start .start.*)     /* Place __start here */
       *(.text .text.*)
       *(.text.cold)
       *(.text.unlikely)

--- a/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
+++ b/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
@@ -33,6 +33,7 @@ SECTIONS
   _start = .;
   .text : {
         _stext = .;            /* Text section */
+       *(.start .start.*)      /* Place __start here */
        *(.text)
        *(.text.cold)
        *(.text.unlikely)

--- a/boards/arm64/rk3399/nanopi_m4/scripts/dramboot.ld
+++ b/boards/arm64/rk3399/nanopi_m4/scripts/dramboot.ld
@@ -43,6 +43,7 @@ SECTIONS
   _start = .;
   .text : {
         _stext = .;            /* Text section */
+       *(.start .start.*)      /* Place __start here */
        *(.text)
        *(.text.cold)
        *(.text.unlikely)

--- a/boards/arm64/rk3399/pinephonepro/scripts/dramboot.ld
+++ b/boards/arm64/rk3399/pinephonepro/scripts/dramboot.ld
@@ -34,6 +34,7 @@ SECTIONS
   _start = .;
   .text : {
         _stext = .;            /* Text section */
+       *(.start .start.*)      /* Place __start here */
        *(.text)
        *(.text.cold)
        *(.text.unlikely)


### PR DESCRIPTION
As __start must be placed at a precise location, a separate, explicit input section is needed to guarantee this.

Why is this an issue ? NuttX uses --entry=__start which puts __start in its correct location, but out-of-tree builds won't work, so it more robust to use an explicit section for the startup code and enforce its placement in the linker script.

