### PR TITLE
[1.13.3 FC_ONLY] USB and I2C fix

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corespi.c
+++ b/arch/risc-v/src/mpfs/mpfs_corespi.c
@@ -928,6 +928,18 @@ static void mpfs_spi_irq_exchange(struct mpfs_spi_priv_s *priv,
                                 MPFS_SPI_INTTXDONE,
                                 0);
 
+  /* TX_DONE interrupt can be received after a semaphore timeout, but before
+   * interrupts are disabled. This will leave the semaphore to the signaled
+   * state.
+   * After a timeout the semaphore is always reset to non-signaled state
+   * to fix this race condition.
+   */
+
+  if (priv->error == -ETIMEDOUT)
+    {
+      nxsem_reset(&priv->sem_isr, 0);
+    }
+
   putreg32(MPFS_SPI_TXCHUNDRUN |
            MPFS_SPI_RXCHOVRFLW |
            MPFS_SPI_DATA_RX |

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -425,6 +425,8 @@ static int mpfs_i2c_init(struct mpfs_i2c_priv_s *priv)
 
       putreg32(MPFS_I2C_CTRL_ENS1_MASK, MPFS_I2C_CTRL);
 
+      nxsem_reset(&priv->sem_isr, 0);
+
       priv->initialized = true;
     }
 
@@ -469,8 +471,27 @@ static void mpfs_i2c_deinit(struct mpfs_i2c_priv_s *priv)
 
 static int mpfs_i2c_sem_waitdone(struct mpfs_i2c_priv_s *priv)
 {
+  int res = 0;
   uint32_t timeout = mpfs_i2c_timeout(priv->msgc, priv->msgv);
-  return nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout));
+
+  res = nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout));
+
+  /* -> race condition <- */
+
+  priv->inflight = false;
+
+  /* Handle a race condition above in which interrupt MPFS_I2C_ST_STOP_SENT
+   * was received right after semaphore timeout. In that case semaphore is
+   * signalled and has the incorrect state when the next transfer starts.
+   */
+
+  if (res < 0)
+    {
+      res = nxsem_tickwait_uninterruptible(&priv->sem_isr,
+                                           USEC2TICK(timeout));
+    }
+
+  return res;
 }
 
 /****************************************************************************
@@ -872,7 +893,6 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
       if (mpfs_i2c_sem_waitdone(priv) < 0)
         {
           i2cinfo("Message %" PRIu8 " timed out.\n", priv->msgid);
-          priv->inflight = false;
           ret = -ETIMEDOUT;
           break;
         }
@@ -932,6 +952,8 @@ static int mpfs_i2c_reset(struct i2c_master_s *dev)
   int ret;
 
   nxmutex_lock(&priv->lock);
+
+  i2cerr("i2c bus %d reset\n", priv->id);
 
   mpfs_i2c_deinit(priv);
 

--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -3478,7 +3478,7 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
 
   if (pending_tx_ep != 0)
     {
-      for (i = 1; i < MPFS_USB_NENDPOINTS; i++)
+      for (i = 1; i < (MPFS_USB_NENDPOINTS / 2 + 1); i++)
         {
           if ((pending_tx_ep & (1 << i)) != 0)
             {
@@ -3489,20 +3489,27 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
 
   if (pending_rx_ep != 0)
     {
-      for (i = 0; i < MPFS_USB_NENDPOINTS; i++)
+      for (i = 1; i < (MPFS_USB_NENDPOINTS / 2 + 1); i++)
         {
           /* Check if dead connections are back in business */
 
           if (g_linkdead)
             {
-              /* This releases all, which is a problem if only some
-               * endpoints are closed on the remote; whereas some
-               * are functioning; for example ACM and mass storage;
-               * now the functioning one likely marks the closed ones
-               * as no longer dead.
+              /* This releases all tx counterparts with linkdead flag
+               * set, which is a problem if only some endpoints are
+               * closed on the remote; whereas some are functioning;
+               * for example ACM and mass storage; now the functioning
+               * one likely marks the closed ones as no longer dead.
+               * Please note that tx counterparts have MPFS_EPIN_START
+               * offset on top of the rx eps.
+               *
+               * For clarity, the eplist[] is as follows:
+               * eplist: 0:   ep0,
+               *         1-4: ep1rx, ep2rx, ep3rx, ep4rx,
+               *         5-8: ep1tx, ep2tx, ep3tx, ep4tx
                */
 
-              struct mpfs_ep_s *privep = &priv->eplist[i];
+              struct mpfs_ep_s *privep = &priv->eplist[i + MPFS_EPIN_START];
               privep->linkdead = 0;
             }
 


### PR DESCRIPTION
- cherry-picked usb patch from mainline
- fixed semaphore race condition in i2c-driver