### PR TITLE
Remove build errors in bootloader

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -103,8 +103,8 @@ typedef struct sbi_scratch_holder_s sbi_scratch_holder_t;
 
 extern const uint8_t __mpfs_nuttx_start[];
 extern const uint8_t __mpfs_nuttx_end[];
-extern const uint8_t _ssbi_ddr[];
-extern const uint8_t _esbi_ddr[];
+extern const uint8_t _ssbi_ram[];
+extern const uint8_t _esbi_ram[];
 
 /****************************************************************************
  * Private Function Prototypes
@@ -475,9 +475,9 @@ static void mpfs_opensbi_scratch_setup(uint32_t hartid)
    * them so that OpenSBI has no chance override then.
    */
 
-  g_scratches[hartid].scratch.fw_start = (unsigned long)_ssbi_ddr;
-  g_scratches[hartid].scratch.fw_size  = (unsigned long)_esbi_ddr -
-                                         (unsigned long)_ssbi_ddr;
+  g_scratches[hartid].scratch.fw_start = (unsigned long)_ssbi_ram;
+  g_scratches[hartid].scratch.fw_size  = (unsigned long)_esbi_ram -
+                                         (unsigned long)_ssbi_ram;
 
   g_scratches[hartid].scratch.fw_rw_offset =
       (unsigned long)g_scratches[hartid].scratch.fw_size;

--- a/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
@@ -43,17 +43,17 @@
 
   /* Add some weak default values to make this compile without */
 
-  .weak  _sbi_zerodev_loadaddr
-  .weak  _ssbi_zerodev
-  .weak  _esbi_zerodev
+  .weak  _sbi_ram_loadaddr
+  .weak  _ssbi_ram
+  .weak  _esbi_ram
 
   /* These are the weak pointless variables, only to get this PR compile */
 
-_sbi_zerodev_loadaddr:
+_sbi_ram_loadaddr:
   .dword  0x0a006000
-_ssbi_zerodev:
+_ssbi_ram:
   .dword  _stext
-_esbi_zerodev:
+_esbi_ram:
   .dword  _stext
 
 /****************************************************************************
@@ -89,9 +89,9 @@ mpfs_opensbi_relocate_from_envm:
 
   /* Relocate the code from eNVM into L2 zero device */
 
-  la    a0, _sbi_zerodev_loadaddr
-  la    a1, _ssbi_zerodev
-  la    a2, _esbi_zerodev
+  la    a0, _sbi_ram_loadaddr
+  la    a1, _ssbi_ram
+  la    a2, _esbi_ram
 .check_if_opensbi_copy_done:
   bge   a1, a2, .opensbi_copy_done
   ld    a3, 0(a0)

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -36,12 +36,12 @@ SECTIONS
     PROVIDE(__l2lim_end   = ORIGIN(l2lim) + LENGTH(l2lim));
 
     .text.sbi : {
-      _ssbi_ddr = ABSOLUTE(.);
+      _ssbi_ram = ABSOLUTE(.);
       sbi*
       riscv_atomic*
       riscv_locks*
       riscv_asm*
-      _esbi_ddr = ABSOLUTE(.);
+      _esbi_ram = ABSOLUTE(.);
       . = ALIGN(0x2000);
       . += 16k; /* OpenSBI heap, aligned, at least 16k */
     } > ddr

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -48,7 +48,6 @@
 #endif
 
 #ifndef CONFIG_TLS_NELEM
-#  warning CONFIG_TLS_NELEM is not defined
 #  define CONFIG_TLS_NELEM 0
 #endif
 


### PR DESCRIPTION
## Summary

This for updating the nuttx in the saluki_bootloader_v2.

The tls warning removal is a direct cherry-pick from upstream.

Renaming the linker symbols is just a clean up; these same symbols are _ssbi_zerodev and _esbi_zerodev in the nuttx version in the bootloader currently.

Change the name to something that doesn't indicate where the sbi executable ram area is, it is anyhow determined in the linker script.
