### PR TITLE
boards/risc-v/mpfs/common/src: Update mpfs_emmcsd.c and mpfs_composite.c

### DIFF
--- a/boards/risc-v/mpfs/common/src/mpfs_composite.c
+++ b/boards/risc-v/mpfs/common/src/mpfs_composite.c
@@ -34,7 +34,7 @@
 
 #include "mpfs.h"
 
-#if defined(CONFIG_BOARDCTL_USBDEVCTRL) && defined(CONFIG_USBDEV_COMPOSITE)
+#if defined(CONFIG_USBDEV_COMPOSITE)
 
 /****************************************************************************
  * Private Data
@@ -175,6 +175,28 @@ int board_composite_initialize(int port)
 #endif
 
 /****************************************************************************
+ * Name: board_composite_uninitialize
+ *
+ * Description:
+ *   Perform architecture specific initialization of a composite USB device.
+ *
+ * Input Parameters:
+ *   port   - port number, unused
+ *
+ * Returned Value:
+ *   OK always
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_USBMSC_COMPOSITE
+int board_composite_uninitialize(int port)
+{
+  board_mscuninitialize(NULL);
+  return OK;
+}
+#endif
+
+/****************************************************************************
  * Name: board_usbmsc_initialize
  *
  * Description:
@@ -218,91 +240,95 @@ void *board_composite_connect(int port, int configid)
    * The standard is to use one CDC/ACM and one USB mass storage device.
    */
 
-  if (configid == 0)
-    {
-#ifdef CONFIG_USBMSC_COMPOSITE
-      struct composite_devdesc_s dev[2];
-      int ifnobase = 0;
-      int strbase  = COMPOSITE_NSTRIDS;
+  struct composite_devdesc_s dev[2];
+  int devs = 0;
+  int ifnobase = 0;
+  int strbase  = COMPOSITE_NSTRIDS;
 
+  if (configid == 0 || configid == 1)
+    {
+#ifdef CONFIG_CDCACM_COMPOSITE
       /* Configure the CDC/ACM device */
 
       /* Ask the cdcacm driver to fill in the constants we didn't
        * know here.
        */
 
-      cdcacm_get_composite_devdesc(&dev[0]);
+      cdcacm_get_composite_devdesc(&dev[devs]);
 
       /* Overwrite and correct some values... */
 
       /* The callback functions for the CDC/ACM class */
 
-      dev[0].classobject  = cdcacm_classobject;
-      dev[0].uninitialize = cdcacm_uninitialize;
+      dev[devs].classobject  = cdcacm_classobject;
+      dev[devs].uninitialize = cdcacm_uninitialize;
 
       /* Interfaces */
 
-      dev[0].devinfo.ifnobase = ifnobase;    /* Offset to Interface-IDs */
-      dev[0].minor = 0;                      /* The minor interface number */
+      dev[devs].devinfo.ifnobase = ifnobase;    /* Offset to Interface-IDs */
+      dev[devs].minor = 0;                      /* The minor interface number */
 
       /* Strings */
 
-      dev[0].devinfo.strbase = strbase;      /* Offset to String Numbers */
+      dev[devs].devinfo.strbase = strbase;      /* Offset to String Numbers */
 
       /* Endpoints */
 
-      dev[0].devinfo.epno[CDCACM_EP_BULKIN_IDX]  = 3;
-      dev[0].devinfo.epno[CDCACM_EP_BULKOUT_IDX] = 3;
-      dev[0].devinfo.epno[CDCACM_EP_INTIN_IDX]   = 4;
+      dev[devs].devinfo.epno[CDCACM_EP_BULKIN_IDX]  = 3;
+      dev[devs].devinfo.epno[CDCACM_EP_BULKOUT_IDX] = 3;
+      dev[devs].devinfo.epno[CDCACM_EP_INTIN_IDX]   = 4;
 
       /* Count up the base numbers */
 
-      ifnobase += dev[0].devinfo.ninterfaces;
-      strbase  += dev[0].devinfo.nstrings;
+      ifnobase += dev[devs].devinfo.ninterfaces;
+      strbase  += dev[devs].devinfo.nstrings;
 
+      devs++;
+#endif
+    }
+
+  if (configid == 1)
+    {
+#ifdef CONFIG_USBMSC_COMPOSITE
       /* Configure the mass storage device device */
 
       /* Ask the usbmsc driver to fill in the constants we didn't
        * know here.
        */
 
-      usbmsc_get_composite_devdesc(&dev[1]);
+      usbmsc_get_composite_devdesc(&dev[devs]);
 
       /* Overwrite and correct some values... */
 
       /* The callback functions for the USBMSC class */
 
-      dev[1].classobject  = board_mscclassobject;
-      dev[1].uninitialize = board_mscuninitialize;
+      dev[devs].classobject  = board_mscclassobject;
+      dev[devs].uninitialize = board_mscuninitialize;
 
       /* Interfaces */
 
-      dev[1].devinfo.ifnobase = ifnobase;               /* Offset to Interface-IDs */
-      dev[1].minor = 0;                                 /* The minor interface number */
+      dev[devs].devinfo.ifnobase = ifnobase;               /* Offset to Interface-IDs */
+      dev[devs].minor = 0;                                 /* The minor interface number */
 
       /* Strings */
 
-      dev[1].devinfo.strbase = strbase;                 /* Offset to String Numbers */
+      dev[devs].devinfo.strbase = strbase;                 /* Offset to String Numbers */
 
       /* Endpoints */
 
-      dev[1].devinfo.epno[USBMSC_EP_BULKIN_IDX]  = 1;
-      dev[1].devinfo.epno[USBMSC_EP_BULKOUT_IDX] = 2;
+      dev[devs].devinfo.epno[USBMSC_EP_BULKIN_IDX]  = 1;
+      dev[devs].devinfo.epno[USBMSC_EP_BULKOUT_IDX] = 2;
 
       /* Count up the base numbers */
 
-      ifnobase += dev[1].devinfo.ninterfaces;
-      strbase  += dev[1].devinfo.nstrings;
+      ifnobase += dev[devs].devinfo.ninterfaces;
+      strbase  += dev[devs].devinfo.nstrings;
 
-      return composite_initialize(composite_getdevdescs(), dev, 2);
-#else
-      return NULL;
+      devs++;
 #endif
     }
-  else
-    {
-      return NULL;
-    }
+
+  return composite_initialize(composite_getdevdescs(), dev, devs);
 }
 
-#endif /* CONFIG_BOARDCTL_USBDEVCTRL && CONFIG_USBDEV_COMPOSITE */
+#endif /* CONFIG_USBDEV_COMPOSITE */

--- a/boards/risc-v/mpfs/common/src/mpfs_usb.c
+++ b/boards/risc-v/mpfs/common/src/mpfs_usb.c
@@ -75,7 +75,7 @@ int mpfs_board_usb_init(void)
       return ret;
     }
 
-  if (board_composite_connect(0, 0) == NULL)
+  if (board_composite_connect(0, 1) == NULL)
     {
       syslog(LOG_ERR, "Failed to connect composite: %d\n", ret);
       return ret;


### PR DESCRIPTION
Add partition parsing logic to emmcsd and support for configuring either CDCACM alone or both CDCACM and USBMCS for composite mode.

This is a direct cherry-pick from upstream -> merging as is