### PR TITLE
riscv_pmp.c: Check that size is power of two for NAPOT

### DIFF
--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -134,9 +134,9 @@ static bool pmp_check_region_attrs(uintptr_t base, uintptr_t size,
 
     case PMPCFG_A_NAPOT:
       {
-        /* For NAPOT, both base and size must be properly aligned */
+        /* For NAPOT, Naturally aligned power-of-two region, >= 8 bytes */
 
-        if ((base & 0x07) != 0 || size < 8)
+        if ((base & 0x07) != 0 || size < 8 || (size & (size - 1)) != 0)
           {
             return false;
           }

--- a/arch/risc-v/src/mpfs/mpfs_mpu.c
+++ b/arch/risc-v/src/mpfs/mpfs_mpu.c
@@ -159,9 +159,11 @@ int mpfs_mpu_set(uintptr_t reg, uintptr_t perm, uintptr_t base,
       return -EACCES;
     }
 
-  /* Base must be word aligned, minimum size is 4K */
+  /* Base must be word aligned,
+   * minimum size is 4K and it has to be power-of-two
+   */
 
-  if ((base & 0x07) != 0 || size < 0x1000)
+  if ((base & 0x07) != 0 || size < 0x1000 || (size & (size - 1)) != 0)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
The size must be power-of-two according to the the PMP spec.