### PR TITLE
mpfs_ethernet.c: increase GMAC_RX_UNITSIZE

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -134,8 +134,8 @@
  * issue when using the MTU size receive block
  */
 
-#define GMAC_RX_UNITSIZE  (512)                  /* Fixed size for RX buffer */
-#define GMAC_TX_UNITSIZE  CONFIG_NET_ETH_PKTSIZE /* MAX size for Ethernet packet */
+#define GMAC_RX_UNITSIZE  CONFIG_NET_ETH_PKTSIZE /* MAX size of RX ethernet packet */
+#define GMAC_TX_UNITSIZE  CONFIG_NET_ETH_PKTSIZE /* MAX size of TX ethernet packet */
 
 /* The MAC can support frame lengths up to 1536 bytes */
 


### PR DESCRIPTION
Set RX buffer size to max frame length to be able to receive MC side MTU size frames
