### PR TITLE
arm64: fix jump address to el2 entry when leaving el3

### DIFF
--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -243,10 +243,8 @@ switch_el:
     mov   sp, x24
     b     el3_boot
 #endif
-
-    /* Get next EL */
-
-    adr   x0, switch_el
+    /* Jump to EL2 */
+    adr   x0, 2f
     bl    arm64_boot_el3_get_next_el
     eret
 #endif


### PR DESCRIPTION
## Summary

## Impact

## Testing

