### PR TITLE
Imx93 po patches to nuttx

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -16,7 +16,6 @@ config ARCH_CHIP_IMX93
 	select ARCH_HAVE_MULTICPU
 	select ARMV8A_HAVE_GICv3
 	select ARCH_CORTEX_A55
-	select ARCH_HAVE_PSCI if !IMX9_BOOTLOADER
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_RESET
 
@@ -46,6 +45,15 @@ config IMX9_FLEXIO_PWM
 	bool
 	select PWM_MULTICHAN
 	default n
+
+config IMX9_HAVE_ATF_FIRMWARE
+	bool "ARM ATF services support in bootloader"
+	default y
+	select ARCH_HAVE_PSCI
+	---help---
+		Configure this N if using Nuttx bootloader that does not
+		implemet EL3 services, by default this is y when using uboot as
+		a booloader
 
 config IMX9_BOOTLOADER
 	bool "Bootloader"

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -344,7 +344,7 @@ static int tca64_putreg(struct tca64_dev_s *priv, uint8_t regaddr,
   else
     {
       gpioinfo("claddr=%02x, regaddr=%02x, regval=%02x\n",
-               priv->config->address, regaddr, regval);
+               priv->config->address, regaddr, *regval);
       return OK;
     }
 }
@@ -1349,7 +1349,6 @@ tca64_initialize(FAR struct i2c_master_s *i2c,
                  FAR struct tca64_config_s *config)
 {
   FAR struct tca64_dev_s *priv;
-  int ret;
 
 #ifdef CONFIG_TCA64XX_MULTIPLE
   /* Allocate the device state structure */
@@ -1382,7 +1381,7 @@ tca64_initialize(FAR struct i2c_master_s *i2c,
 #ifdef CONFIG_TCA64XX_INT_POLL
   /* Set up a timer to poll for missed interrupts */
 
-  ret = wd_start(&priv->wdog, TCA64XX_POLLDELAY,
+  int ret = wd_start(&priv->wdog, TCA64XX_POLLDELAY,
                  tca64_poll_expiry, (wdparm_t)priv);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
When using nuttx bootloader psci is not available in system, so chage logic so that it is behind new
configuration flag. 

Other patch fixes minor compilation errors on tca64xx ioexpander driver

## Impact

## Testing

