### PR TITLE
Imx9 i2c fixes

### DIFF
--- a/arch/arm64/src/imx9/hardware/imx9_lpi2c.h
+++ b/arch/arm64/src/imx9/hardware/imx9_lpi2c.h
@@ -296,7 +296,10 @@
                                                       /* Bits 7-3 Reserved */
 #define LPI2C_MCFG0_CIRFIFO                 (1 << 8)  /* Circular FIFO Enable Bit */
 #define LPI2C_MCFG0_RDMO                    (1 << 9)  /* Receive Data Match Only Bit */
-                                                      /* Bits 31-10 Reserved */
+                                                      /* Bits 15-10 Reserved */
+#define LPI2C_MCFG0_RELAX                   (1 << 16) /* Relaxed Mode */
+#define LPI2C_MCFG0_ABORT                   (1 << 17) /* Abort Transfer */
+                                                      /* Bits 31-18 Reserved */
 
 /* LPI2C Master Config Register 1  */
 

--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -1311,14 +1311,10 @@ static int imx9_lpi2c_start_message(struct imx9_lpi2c_priv_s *priv)
   priv->dcnt  = priv->msgv->length;
   priv->flags = priv->msgv->flags;
 
-  /* Enable RX interrupt before sending START in order not to miss it */
+  /* Disable ABORT which may be present after errors */
 
-  if ((priv->flags & I2C_M_READ) != 0)
-    {
-      irq_config |= LPI2C_MIER_RDIE;
-    }
-
-  imx9_lpi2c_putreg(priv, IMX9_LPI2C_MIER_OFFSET, irq_config);
+  imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MCFGR0_OFFSET,
+                       LPI2C_MCFG0_ABORT, 0);
 
   /* Send start + address unless M_NOSTART is defined */
 
@@ -1331,27 +1327,22 @@ static int imx9_lpi2c_start_message(struct imx9_lpi2c_priv_s *priv)
   else
     {
       imx9_lpi2c_traceevent(priv, I2CEVENT_NOSTART, priv->msgc);
-
-      if ((priv->flags & I2C_M_READ) == 0)
-        {
-          /* We didn't send start, send the first byte to trigger TX IRQs */
-
-          imx9_lpi2c_putreg(priv, IMX9_LPI2C_MTDR_OFFSET,
-                            LPI2C_MTDR_CMD_TXD |
-                            LPI2C_MTDR_DATA(*priv->ptr++));
-          priv->dcnt--;
-        }
     }
-
-  /* Enable TX interrupt after sending the first byte - before sending
-   * anything the FIFO count is at 0, so the TX interrupt would trigger
-   * right away
-   */
 
   if ((priv->flags & I2C_M_READ) == 0)
     {
+      /* Queue the first byte. NB: if start was sent and NACK received,
+       * the byte won't be sent out to the bus.
+       */
+
+      imx9_lpi2c_putreg(priv, IMX9_LPI2C_MTDR_OFFSET,
+                        LPI2C_MTDR_CMD_TXD |
+                        LPI2C_MTDR_DATA(*priv->ptr++));
+      priv->dcnt--;
+
+      /* Enable TX interrupt */
+
       irq_config |= LPI2C_MIER_TDIE;
-      imx9_lpi2c_putreg(priv, IMX9_LPI2C_MIER_OFFSET, irq_config);
     }
   else
     {
@@ -1360,7 +1351,13 @@ static int imx9_lpi2c_start_message(struct imx9_lpi2c_priv_s *priv)
       imx9_lpi2c_putreg(priv, IMX9_LPI2C_MTDR_OFFSET,
                         LPI2C_MTDR_CMD_RXD |
                         LPI2C_MTDR_DATA((priv->dcnt - 1)));
+
+      /* Enable RX interrupt */
+
+      irq_config |= LPI2C_MIER_RDIE;
     }
+
+  imx9_lpi2c_putreg(priv, IMX9_LPI2C_MIER_OFFSET, irq_config);
 
   return OK;
 }
@@ -1510,23 +1507,32 @@ static int imx9_lpi2c_isr_process(struct imx9_lpi2c_priv_s *priv)
       imx9_lpi2c_putreg(priv, IMX9_LPI2C_MSR_OFFSET,
                         status & LPI2C_MSR_ERROR_MASK);
 
-      priv->status = status;
-      priv->msgc = 0;
-      priv->dcnt = 0;
-
-      /* If there is no stop condition on the bus after clearing the error,
-       * send stop. Otherwise stop the transfer now.
+      /* If there is no stop condition on the bus, abort (send stop).
+       * Otherwise stop the transfer now.
        */
 
-      status = imx9_lpi2c_getstatus(priv);
       if ((status & LPI2C_MSR_SDF) == 0)
         {
-          imx9_lpi2c_sendstop(priv);
+          /* Disable RX and TX interrupts */
+
+          imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MIER_OFFSET,
+                               LPI2C_MIER_TDIE | LPI2C_MIER_TDIE, 0);
+
+          /* Abort any ongoing transfer, this also sends stop on the bus */
+
+          imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MCFGR0_OFFSET, 0,
+                               LPI2C_MCFG0_ABORT);
         }
       else
         {
           imx9_lpi2c_stop_transfer(priv);
         }
+
+      /* Mark that there are no more messages to process */
+
+      priv->status = status;
+      priv->msgc = 0;
+      priv->dcnt = 0;
 
       return OK;
     }

--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -1485,9 +1485,10 @@ static int imx9_lpi2c_isr_process(struct imx9_lpi2c_priv_s *priv)
 
   /* Ignore NACK on RX last byte - this is normal */
 
-  if ((status & LPI2C_MSR_NDF) != 0 && (priv->flags & I2C_M_READ) != 0 &&
-      priv->dcnt == 1)
+  if ((status & (LPI2C_MSR_RDF | LPI2C_MSR_NDF)) ==
+      (LPI2C_MSR_RDF | LPI2C_MSR_NDF) && priv->dcnt == 1)
     {
+      imx9_lpi2c_putreg(priv, IMX9_LPI2C_MSR_OFFSET, LPI2C_MSR_NDF);
       status &= ~LPI2C_MSR_NDF;
     }
 


### PR DESCRIPTION
This adds some more robust error handling to the imx9 i2c

- Added cleanup in case of timeout
- Irq:s are enabled at once
