### PR TITLE
mpfs_serial.c: Add RX flowcontrol

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_serial.c
+++ b/arch/risc-v/src/mpfs/mpfs_serial.c
@@ -161,6 +161,10 @@ static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_receive(struct uart_dev_s *dev, unsigned int *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
 static bool up_rxavailable(struct uart_dev_s *dev);
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+static bool up_rxflowcontrol(struct uart_dev_s *dev,
+                             unsigned int nbuffered, bool upper);
+#endif
 static void up_send(struct uart_dev_s *dev, int ch);
 static void up_txint(struct uart_dev_s *dev, bool enable);
 static bool up_txready(struct uart_dev_s *dev);
@@ -181,7 +185,7 @@ static const struct uart_ops_s g_uart_ops =
   .rxint          = up_rxint,
   .rxavailable    = up_rxavailable,
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-  .rxflowcontrol  = NULL,
+  .rxflowcontrol  = up_rxflowcontrol,
 #endif
   .send           = up_send,
   .txint          = up_txint,
@@ -1342,6 +1346,47 @@ static bool up_rxavailable(struct uart_dev_s *dev)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   return ((up_serialin(priv, MPFS_UART_LSR_OFFSET) & UART_LSR_DR) != 0);
 }
+
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+/****************************************************************************
+ * Name: up_rxflowcontrol
+ *
+ * Description:
+ *   Basic flowcontrol functionality.
+ *   Disable RX interrupts and clear the fifo in case of full RX buffer.
+ *   Enable RX interrupts in case of empty buffer.
+ *   Return true if RX FIFO was cleared.
+ *
+ ****************************************************************************/
+
+static bool up_rxflowcontrol(struct uart_dev_s *dev,
+                             unsigned int nbuffered, bool upper)
+{
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
+  bool ret = false;
+
+  if (nbuffered == 0 || upper == false)
+    {
+      /* Empty buffer. Enable RX ints */
+
+      up_rxint(dev, true);
+
+      ret = false;
+    }
+  else
+    {
+      /* Full buffer. Disable RX ints and clear the RX FIFO */
+
+      up_rxint(dev, false);
+
+      up_serialout(priv, MPFS_UART_FCR_OFFSET, UART_FCR_RFIFOR);
+
+      ret = true;
+    }
+
+  return ret;
+}
+#endif
 
 /****************************************************************************
  * Name: up_send


### PR DESCRIPTION
This is very basic functionality what we have here as we don't have RTS / CTS Flow Control in Saluki.
Disable RX interrupts and clear the FIFO in case of full RX buffer. Enable RX interrupts in case of empty buffer.

