### PR TITLE
arch/arm64/imx9 Usb driver cache

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -395,7 +395,7 @@ static int cdcacm_sndpacket(FAR struct cdcacm_dev_s *priv)
 
   /* Get the maximum number of bytes that will fit into one bulk IN request */
 
-  reqlen = MAX(CONFIG_CDCACM_BULKIN_REQLEN, ep->maxpacket);
+  reqlen = MIN(CONFIG_CDCACM_BULKIN_REQLEN, ep->maxpacket);
 
   while (!sq_empty(&priv->txfree))
     {

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -636,7 +636,7 @@ static int usbclass_sndpacket(FAR struct pl2303_dev_s *priv)
 
   /* Get the maximum number of bytes that will fit into one bulk IN request */
 
-  reqlen = MAX(CONFIG_PL2303_BULKIN_REQLEN, ep->maxpacket);
+  reqlen = MIN(CONFIG_PL2303_BULKIN_REQLEN, ep->maxpacket);
 
   while (!sq_empty(&priv->reqlist))
     {


### PR DESCRIPTION
Modify cache clean/invalidate to get
mass-storage transfer work.

## Summary

## Impact

## Testing

