### PR TITLE
usbdev/cdcacm: Fix read queue counter in shutdown

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -1125,7 +1125,10 @@ static void cdcacm_rdcomplete(FAR struct usbdev_ep_s *ep,
     case -ESHUTDOWN: /* Disconnection */
       {
         usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_RDSHUTDOWN), 0);
-        priv->nrdq--;
+        if (priv->nrdq != 0)
+          {
+            priv->nrdq--;
+          }
       }
       break;
 


### PR DESCRIPTION
nrdq is already set 0 in resetconfig.

## Summary

## Impact

## Testing

