### PR TITLE
arch/arm64/src/imx9/Kconfig: Enable FAT_DMAMEMORY and FORCE_INDIRECT …

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -90,8 +90,11 @@ menu "USDHC"
 
 config IMX9_USDHC
 	bool
-	default n
 	select ARCH_HAVE_SDIO_PREFLIGHT
+	select FAT_DMAMEMORY
+	select FAT_FORCE_INDIRECT
+	select GRAN
+	default n
 
 config IMX9_USDHC1
 	bool "USDHC1"


### PR DESCRIPTION
I am not 100% sure whether FORCE_INDERECT is needeed for imx9, but it was enabled for MPFS, so probably. 
