### PR TITLE
drivers/audio/wm8994.c: Include nuttx/arch.h to fix compilation (up_m…

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_timerisr.c
+++ b/arch/risc-v/src/mpfs/mpfs_timerisr.c
@@ -37,6 +37,7 @@
 
 #include "mpfs.h"
 #include "mpfs_clockconfig.h"
+#include "riscv_sbi.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/drivers/audio/wm8994.c
+++ b/drivers/audio/wm8994.c
@@ -38,6 +38,7 @@
 #include <fixedmath.h>
 #include <debug.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/clock.h>


### PR DESCRIPTION
Fixes this error:

audio/wm8994.c: In function 'wm8994_audio_output':
Error: audio/wm8994.c:1898:3: error: implicit declaration of function 'up_mdelay' [-Werror=implicit-function-declaration]
 1898 |   up_mdelay(40);
      |   ^~~~~~~~~