### PR TITLE
nxsem_destroyholder: Use critical section when destroying holder(s)

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -558,6 +558,8 @@ void nxsem_initialize_holders(void)
 
 void nxsem_destroyholder(FAR sem_t *sem)
 {
+  irqstate_t flags = enter_critical_section();
+
   /* It might be an error if a semaphore is destroyed while there are any
    * holders of the semaphore (except perhaps the thread that release the
    * semaphore itself).  We actually have to assume that the caller knows
@@ -592,6 +594,8 @@ void nxsem_destroyholder(FAR sem_t *sem)
 #endif
 
   nxsem_foreachholder(sem, nxsem_recoverholders, NULL);
+
+  leave_critical_section(flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
From upstream