### PR TITLE
fs/driver: fix unregister with CONFIG_DISABLE_PSEUDOFS_OPERATIONS

### DIFF
--- a/fs/driver/fs_unregisterdriver.c
+++ b/fs/driver/fs_unregisterdriver.c
@@ -50,10 +50,12 @@ int unregister_driver(FAR const char *path)
   /* Call unlink to release driver resource and inode. */
 
   ret = nx_unlink(path);
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   if (ret >= 0)
     {
       return ret;
     }
+#endif
 
   /* If unlink failed, only remove inode. */
 


### PR DESCRIPTION
If CONFIG_DISABLE_PSEUDOFS_OPERATIONS is set, the inode doesn't get removed at all. This may be hacky, but remove it forcibly for now.

## Summary

If CONFIG_DISABLE_PSEUDOFS_OPERATIONS is not set (like now), fs code has a bug that corrupts memory. Thus, avoid this situation at all cost.

## Impact


## Testing




