### PR TITLE
pthread_cond_wait: Use atomic_t to protect the waiter count

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -808,7 +808,7 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
 #ifdef CONFIG_DEBUG_I2C_ERROR
   /* We should never start at transfer with semaphore already signalled */
 
-  sem_getvalue(&priv->sem_isr, &sval);
+  nxsem_get_value(&priv->sem_isr, &sval);
   if (sval != 0)
     {
       i2cerr("Already signalled at start? %d\n", sval);

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -1462,7 +1462,7 @@ static void fb_sem_post(FAR struct fb_chardev_s *fb, int overlay)
         {
           int semcount = 0;
 
-          sem_getvalue(&priv->wait, &semcount);
+          nxsem_get_value(&priv->wait, &semcount);
           if (semcount >= 0)
             {
               break;

--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -93,6 +93,17 @@ extern "C++"
 #  include <nuttx/lib/stdatomic.h>
 #endif
 
+#ifndef atomic_read
+#define atomic_read atomic_load
+#endif
+
+#ifndef atomic_cmpxchg
+#define atomic_cmpxchg atomic_compare_exchange_strong
+#endif
+
+typedef volatile int32_t atomic_t;
+typedef volatile int64_t atomic64_t;
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -269,7 +269,7 @@ struct pthread_cond_s
 {
   sem_t sem;
   clockid_t clockid;
-  uint16_t wait_count;
+  int wait_count;
 };
 
 #ifndef __PTHREAD_COND_T_DEFINED

--- a/libs/libc/pthread/pthread_barrierdestroy.c
+++ b/libs/libc/pthread/pthread_barrierdestroy.c
@@ -72,10 +72,10 @@ int pthread_barrier_destroy(FAR pthread_barrier_t *barrier)
     }
   else
     {
-      ret = sem_getvalue(&barrier->sem, &semcount);
-      if (ret != OK)
+      ret = nxsem_get_value(&barrier->sem, &semcount);
+      if (ret < 0)
         {
-          return ret;
+          return -ret;
         }
 
       if (semcount < 0)
@@ -83,7 +83,7 @@ int pthread_barrier_destroy(FAR pthread_barrier_t *barrier)
           return EBUSY;
         }
 
-      sem_destroy(&barrier->sem);
+      ret = -nxsem_destroy(&barrier->sem);
       barrier->count = 0;
     }
 

--- a/libs/libc/pthread/pthread_conddestroy.c
+++ b/libs/libc/pthread/pthread_conddestroy.c
@@ -69,21 +69,18 @@ int pthread_cond_destroy(FAR pthread_cond_t *cond)
 
   else
     {
-      ret = sem_getvalue(&cond->sem, &sval);
+      ret = nxsem_get_value(&cond->sem, &sval);
       if (ret < 0)
         {
           ret = -ret;
         }
+      else if (sval < 0)
+        {
+          ret = EBUSY;
+        }
       else
         {
-          if (sval < 0)
-            {
-              ret = EBUSY;
-            }
-          else if (sem_destroy(&cond->sem) != OK)
-            {
-              ret = get_errno();
-            }
+          ret = -nxsem_destroy(&cond->sem);
         }
     }
 

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -78,6 +78,8 @@
 #  define mutex_setprioceiling(m,p,o) nxmutex_setprioceiling(m,p,o)
 #endif
 
+#define COND_WAIT_COUNT(cond) ((FAR atomic_t *)&(cond)->wait_count)
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/sched/pthread/pthread_condbroadcast.c
+++ b/sched/pthread/pthread_condbroadcast.c
@@ -31,6 +31,8 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/atomic.h>
+
 #include "pthread/pthread.h"
 
 /****************************************************************************
@@ -42,10 +44,7 @@
  *
  * Description:
  *    A thread broadcast on a condition variable.
- *    pthread_cond_broadcast shall unblock all threads currently blocked on a
- *    specified condition variable cond. We need own the mutex that threads
- *    calling pthread_cond_wait or pthread_cond_timedwait have associated
- *    with the condition variable during their wait.
+ *
  * Input Parameters:
  *   None
  *
@@ -68,22 +67,24 @@ int pthread_cond_broadcast(FAR pthread_cond_t *cond)
     }
   else
     {
+      int wcnt = atomic_read(COND_WAIT_COUNT(cond));
+
       /* Loop until all of the waiting threads have been restarted. */
 
-      while (cond->wait_count > 0)
+      while (wcnt > 0)
         {
-          /* If the value is less than zero (meaning that one or more
-           * thread is waiting), then post the condition semaphore.
-           * Only the highest priority waiting thread will get to execute
-           */
+          if (atomic_cmpxchg(COND_WAIT_COUNT(cond), &wcnt, wcnt - 1))
+            {
+              /* Post the condition semaphore to wake up a waiting thread.
+               * Only the highest priority waiting thread will get to execute
+               */
 
-          ret = -nxsem_post(&cond->sem);
+              ret = -nxsem_post(&cond->sem);
 
-          /* Increment the semaphore count (as was done by the
-           * above post).
-           */
+              /* Decrement the waiter count */
 
-          cond->wait_count--;
+              wcnt--;
+            }
         }
     }
 

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -36,6 +36,7 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/atomic.h>
 #include <nuttx/irq.h>
 #include <nuttx/wdog.h>
 #include <nuttx/signal.h>
@@ -113,7 +114,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
       sinfo("Give up mutex...\n");
 
-      cond->wait_count++;
+      atomic_fetch_add(COND_WAIT_COUNT(cond), 1);
 
       /* Give up the mutex */
 

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/atomic.h>
 #include <nuttx/cancelpt.h>
 
 #include "pthread/pthread.h"
@@ -88,7 +89,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
       sinfo("Give up mutex / take cond\n");
 
-      cond->wait_count++;
+      atomic_fetch_add(COND_WAIT_COUNT(cond), 1);
       ret = pthread_mutex_breaklock(mutex, &nlocks);
 
       status = -nxsem_wait_uninterruptible(&cond->sem);


### PR DESCRIPTION
pthread_cond_wait: Use atomic_t to protect the waiter count

From upstream (hopefully)

