### PR TITLE
mpfs: Disable external interrupts on all harts

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -2332,6 +2332,14 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   imx9_serialout(priv, IMX9_LPUART_CTRL_OFFSET, regval);
+
+#ifndef CONFIG_SUPPRESS_SERIAL_INTS
+  if (enable)
+    {
+      uart_xmitchars(dev);
+    }
+#endif
+
   spin_unlock_irqrestore(NULL, flags);
 }
 #endif

--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -101,6 +101,7 @@ void up_irqinitialize(void)
 void up_disable_irq(int irq)
 {
   int extirq = 0;
+  int i;
 
   if (irq == RISCV_IRQ_SOFT)
     {
@@ -117,18 +118,28 @@ void up_disable_irq(int irq)
   else if (irq >= MPFS_IRQ_EXT_START)
     {
       extirq = irq - MPFS_IRQ_EXT_START;
-
-      /* Clear enable bit for the irq */
-
-      uintptr_t iebase = mpfs_plic_get_iebase();
-
-      if (0 <= extirq && extirq <= NR_IRQS - MPFS_IRQ_EXT_START)
-        {
-          modifyreg32(iebase + (4 * (extirq / 32)), 1 << (extirq % 32), 0);
-        }
-      else
+      if (extirq < 0 || extirq > NR_IRQS - MPFS_IRQ_EXT_START)
         {
           PANIC();
+        }
+
+      /* Disable the irq on all harts, we don't know on which it was
+       * enabled
+       */
+
+      for (i = 0; i < CONFIG_SMP_NCPUS; i++)
+        {
+          uintptr_t iebase = mpfs_plic_get_iebase(riscv_cpuid_to_hartid(i));
+          uintptr_t claim_address =
+            mpfs_plic_get_claimbase(riscv_cpuid_to_hartid(i));
+
+          /* Clear enable bit for the irq */
+
+          modifyreg32(iebase + (4 * (extirq / 32)), 1 << (extirq % 32), 0);
+
+          /* Clear any already claimed IRQ */
+
+          putreg32(extirq, claim_address);
         }
     }
 }
@@ -163,7 +174,7 @@ void up_enable_irq(int irq)
 
       /* Set enable bit for the irq */
 
-      uintptr_t iebase = mpfs_plic_get_iebase();
+      uintptr_t iebase = mpfs_plic_get_iebase(up_cpu_index());
 
       if (0 <= extirq && extirq <= NR_IRQS - MPFS_IRQ_EXT_START)
         {

--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -58,7 +58,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   /* Firstly, check if the irq is machine external interrupt */
 
-  uintptr_t claim_address = mpfs_plic_get_claimbase();
+  uintptr_t claim_address = mpfs_plic_get_claimbase(up_cpu_index());
 
   if (irq == RISCV_IRQ_EXT)
     {

--- a/arch/risc-v/src/mpfs/mpfs_plic.c
+++ b/arch/risc-v/src/mpfs/mpfs_plic.c
@@ -56,7 +56,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: get_iebase
+ * Name: mpfs_plic_get_iebase
  *
  * Description:
  *   Get base address for interrupt enable bits for a specific hart.
@@ -69,7 +69,7 @@
  *
  ****************************************************************************/
 
-static uintptr_t get_iebase(uintptr_t hartid)
+uintptr_t mpfs_plic_get_iebase(uintptr_t hartid)
 {
   uintptr_t iebase;
 
@@ -87,7 +87,7 @@ static uintptr_t get_iebase(uintptr_t hartid)
 }
 
 /****************************************************************************
- * Name: get_claimbase
+ * Name: mpfs_plic_get_claimbase
  *
  * Description:
  *   Get base address for interrupt claim for a specific hart.
@@ -100,7 +100,7 @@ static uintptr_t get_iebase(uintptr_t hartid)
  *
  ****************************************************************************/
 
-uintptr_t get_claimbase(uintptr_t hartid)
+uintptr_t mpfs_plic_get_claimbase(uintptr_t hartid)
 {
   uintptr_t claim_address;
 
@@ -171,7 +171,7 @@ void mpfs_plic_init_hart(uintptr_t hartid)
 {
   /* Disable all global interrupts for current hart */
 
-  uintptr_t iebase = get_iebase(hartid);
+  uintptr_t iebase = mpfs_plic_get_iebase(hartid);
 
   putreg32(0x0, iebase + 0);
   putreg32(0x0, iebase + 4);
@@ -185,7 +185,7 @@ void mpfs_plic_init_hart(uintptr_t hartid)
    * This has no effect on non-claimed or disabled interrupts.
    */
 
-  uintptr_t claim_address = get_claimbase(hartid);
+  uintptr_t claim_address = mpfs_plic_get_claimbase(hartid);
 
   for (int irq = MPFS_IRQ_EXT_START; irq < NR_IRQS; irq++)
     {
@@ -196,38 +196,6 @@ void mpfs_plic_init_hart(uintptr_t hartid)
 
   uintptr_t threshold_address = get_thresholdbase(hartid);
   putreg32(0, threshold_address);
-}
-
-/****************************************************************************
- * Name: mpfs_plic_get_iebase
- *
- * Description:
- *   Context aware way to query PLIC interrupt enable base address
- *
- * Returned Value:
- *   Interrupt enable base address
- *
- ****************************************************************************/
-
-uintptr_t mpfs_plic_get_iebase(void)
-{
-  return get_iebase(riscv_mhartid());
-}
-
-/****************************************************************************
- * Name: mpfs_plic_get_claimbase
- *
- * Description:
- *   Context aware way to query PLIC interrupt claim base address
- *
- * Returned Value:
- *   Interrupt enable claim address
- *
- ****************************************************************************/
-
-uintptr_t mpfs_plic_get_claimbase(void)
-{
-  return get_claimbase(riscv_mhartid());
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_plic.h
+++ b/arch/risc-v/src/mpfs/mpfs_plic.h
@@ -58,7 +58,7 @@ void mpfs_plic_init_hart(uintptr_t hartid);
  *
  ****************************************************************************/
 
-uintptr_t mpfs_plic_get_iebase(void);
+uintptr_t mpfs_plic_get_iebase(uintptr_t hartid);
 
 /****************************************************************************
  * Name: mpfs_plic_get_claimbase
@@ -71,7 +71,7 @@ uintptr_t mpfs_plic_get_iebase(void);
  *
  ****************************************************************************/
 
-uintptr_t mpfs_plic_get_claimbase(void);
+uintptr_t mpfs_plic_get_claimbase(uintptr_t hartid);
 
 /****************************************************************************
  * Name: mpfs_plic_get_thresholdbase


### PR DESCRIPTION
Disable external interrupts on all harts

This solves unexpected isr assertion in SMP mode, if console is disabled later after boot

