### PR TITLE
mpfs_i2c: Clean up the logic in i2c_transfer

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_i2c.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_i2c.h
@@ -38,10 +38,21 @@
 #define MPFS_I2C_CTRL_ENS1_MASK       (1 << 6)
 #define MPFS_I2C_CTRL_STA_MASK        (1 << 5)
 #define MPFS_I2C_CTRL_STO_MASK        (1 << 4)
-#define MPFS_I2C_CTRL_SI_MASK         (1 << 3)
+#define MPFS_I2C_CTRL_SI_MASK         (1 << 3) /* Note 1) */
 #define MPFS_I2C_CTRL_AA_MASK         (1 << 2)
 #define MPFS_I2C_CTRL_CR1_MASK        (1 << 1)
 #define MPFS_I2C_CTRL_CR0_MASK        (1 << 0)
+
+/* 1) As an undocumented feature, clearing the pending interrupt (SI) moves
+ *    the I2C IP block's internal state machine forward. This has to be taken
+ *    into account in the driver's internal logic; you must NOT clear the
+ *    interrupt pending bit "as a precaution" or at the wrong time.
+ *
+ *    This necessitates adding logic to e.g. the interrupt handler, where the
+ *    IP's internal state must be moved forward at precise moments, and the
+ *    fact that the interrupt was already cleared must be remembered later.
+ *    This is why 'clear_irq' is used.
+ */
 
 #define MPFS_I2C_ST_IDLE              0xF8  /* No activity, I2C bus idle */
 #define MPFS_I2C_ST_STOP_SENT         0xE0  /* Stop condition has been sent */

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -426,8 +426,6 @@ static int mpfs_i2c_init(struct mpfs_i2c_priv_s *priv)
 
       putreg32(MPFS_I2C_CTRL_ENS1_MASK, MPFS_I2C_CTRL);
 
-      nxsem_reset(&priv->sem_isr, 0);
-
       priv->initialized = true;
     }
 
@@ -472,27 +470,8 @@ static void mpfs_i2c_deinit(struct mpfs_i2c_priv_s *priv)
 
 static int mpfs_i2c_sem_waitdone(struct mpfs_i2c_priv_s *priv)
 {
-  int res = 0;
   uint32_t timeout = mpfs_i2c_timeout(priv->msgc, priv->msgv);
-
-  res = nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout));
-
-  /* -> race condition <- */
-
-  priv->inflight = false;
-
-  /* Handle a race condition above in which interrupt MPFS_I2C_ST_STOP_SENT
-   * was received right after semaphore timeout. In that case semaphore is
-   * signalled and has the incorrect state when the next transfer starts.
-   */
-
-  if (res < 0)
-    {
-      res = nxsem_tickwait_uninterruptible(&priv->sem_isr,
-                                           USEC2TICK(timeout));
-    }
-
-  return res;
+  return nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout));
 }
 
 /****************************************************************************
@@ -894,6 +873,7 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
       if (mpfs_i2c_sem_waitdone(priv) < 0)
         {
           i2cinfo("Message %" PRIu8 " timed out.\n", priv->msgid);
+          priv->inflight = false;
           ret = -ETIMEDOUT;
           break;
         }
@@ -953,8 +933,6 @@ static int mpfs_i2c_reset(struct i2c_master_s *dev)
   int ret;
 
   nxmutex_lock(&priv->lock);
-
-  i2cerr("i2c bus %d reset\n", priv->id);
 
   mpfs_i2c_deinit(priv);
 

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -73,7 +73,7 @@
 /* Gives TTOA in microseconds, ~4.8% bias, +1 rounds up */
 
 #define I2C_TTOA_US(n, f)           ((((n) << 20) / (f)) + 1)
-#define I2C_TTOA_MARGIN             20
+#define I2C_TTOA_MARGIN             1000u
 
 /****************************************************************************
  * Private Types

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -39,6 +39,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/signal.h>
 #include <nuttx/i2c/i2c_master.h>
 
 #include <arch/board/board.h>
@@ -727,6 +728,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
         nxsem_post(&priv->sem_isr);
       }
 
+  /* See note 1) in mpfs_i2c.h why the interrupt cannot be cleared
+   * unconditionally here.
+   */
+
   if (clear_irq)
     {
       /* Clear interrupt. */
@@ -747,7 +752,7 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
  * Name: mpfs_i2c_sendstart
  *
  * Description:
- *   Send I2C start condition and enable the PLIC irq
+ *   Send I2C start condition.
  *
  * Parameters:
  *   priv          - Pointer to the internal driver state structure.
@@ -756,20 +761,64 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
 static void mpfs_i2c_sendstart(struct mpfs_i2c_priv_s *priv)
 {
-  up_enable_irq(priv->plic_irq);
   modifyreg32(MPFS_I2C_CTRL, 0, MPFS_I2C_CTRL_STA_MASK);
 }
 
+/****************************************************************************
+ * Name: mpfs_i2c_force_idle
+ *
+ * Description:
+ *   Attempt to force I2C device to idle state.
+ *
+ * Parameters:
+ *   priv          - Pointer to the internal driver state structure.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success, ERROR is returned on failure.
+ *
+ ****************************************************************************/
+
+static int mpfs_i2c_force_idle(struct mpfs_i2c_priv_s *priv)
+{
+  uint32_t retries = 1000;
+  uint32_t status;
+
+  /* Forcefully send STOP to the bus */
+
+  modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_STA_MASK, MPFS_I2C_CTRL_AA_MASK);
+  modifyreg32(MPFS_I2C_CTRL, 0, MPFS_I2C_CTRL_STO_MASK);
+
+  do
+    {
+      /* Read the status */
+
+      status = getreg32(MPFS_I2C_STATUS);
+
+      if (status == MPFS_I2C_ST_IDLE)
+        {
+          return OK;
+        }
+
+      /* Clear interrupt */
+
+      modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_SI_MASK, 0);
+
+      /* Wait for a while for the command to go through */
+
+      nxsig_usleep(1000);
+    }
+  while (retries--);
+
+  return ERROR;
+}
+
 static int mpfs_i2c_transfer(struct i2c_master_s *dev,
-                                struct i2c_msg_s *msgs,
-                                int count)
+                             struct i2c_msg_s *msgs,
+                             int count)
 {
   struct mpfs_i2c_priv_s *priv = (struct mpfs_i2c_priv_s *)dev;
-  int ret = OK;
-#ifdef CONFIG_DEBUG_I2C_ERROR
-  int sval;
   uint32_t status;
-#endif
+  int ret = OK;
 
   i2cinfo("Starting transfer request of %d message(s):\n", count);
 
@@ -784,26 +833,31 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
       return ret;
     }
 
-#ifdef CONFIG_DEBUG_I2C_ERROR
-  /* We should never start at transfer with semaphore already signalled */
-
-  nxsem_get_value(&priv->sem_isr, &sval);
-  if (sval != 0)
-    {
-      i2cerr("Already signalled at start? %d\n", sval);
-    }
-
   /* We should always be idle before transfer */
 
   status = getreg32(MPFS_I2C_STATUS);
   if (status != MPFS_I2C_ST_IDLE)
     {
       i2cerr("I2C bus not idle before transfer! Status: 0x%x\n", status);
+      if (mpfs_i2c_force_idle(priv) < 0)
+        {
+          ret = -EAGAIN;
+          goto errout_with_mutex;
+        }
     }
-#endif
 
   priv->msgv = msgs;
   priv->msgc = count;
+  priv->inflight = false;
+
+  nxsem_reset(&priv->sem_isr, 0);
+
+  /* Then enable the interrupt. This would also be an opportune moment to
+   * clear any already pending interrupt, but that must not be done. See
+   * comment 1) in mpfs_i2c.h
+   */
+
+  up_enable_irq(priv->plic_irq);
 
   for (int i = 0; i < count; i++)
     {
@@ -844,8 +898,8 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
               if (msgs[i].flags & I2C_M_READ)
                 {
                   i2cerr("No read before write supported!\n");
-                  nxmutex_unlock(&priv->lock);
-                  return -EINVAL;
+                  ret = -EINVAL;
+                  break;
                 }
 
               /* Combine write + read transaction into one */
@@ -873,7 +927,6 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
       if (mpfs_i2c_sem_waitdone(priv) < 0)
         {
           i2cinfo("Message %" PRIu8 " timed out.\n", priv->msgid);
-          priv->inflight = false;
           ret = -ETIMEDOUT;
           break;
         }
@@ -904,10 +957,11 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
     }
 #endif
 
-  /* Irq was enabled at mpfs_i2c_sendstart()  */
+  /* Disable interrupts and get out */
 
   up_disable_irq(priv->plic_irq);
 
+errout_with_mutex:
   nxmutex_unlock(&priv->lock);
   return ret;
 }
@@ -926,6 +980,7 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
  *   Zero (OK) on success; this should not fail.
  *
  ****************************************************************************/
+
 #ifdef CONFIG_I2C_RESET
 static int mpfs_i2c_reset(struct i2c_master_s *dev)
 {
@@ -972,7 +1027,7 @@ static int mpfs_i2c_reset(struct i2c_master_s *dev)
  ****************************************************************************/
 
 static int mpfs_i2c_setfrequency(struct mpfs_i2c_priv_s *priv,
-                                  uint32_t frequency)
+                                 uint32_t frequency)
 {
   uint32_t new_freq = 0;
   uint32_t clock_div = 0;

--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -123,9 +123,7 @@ void up_disable_irq(int irq)
           PANIC();
         }
 
-      /* Disable the irq on all harts, we don't know on which it was
-       * enabled
-       */
+      /* Disable the irq on all harts */
 
       for (i = 0; i < CONFIG_SMP_NCPUS; i++)
         {
@@ -155,6 +153,7 @@ void up_disable_irq(int irq)
 void up_enable_irq(int irq)
 {
   int extirq;
+  int i;
 
   if (irq == RISCV_IRQ_SOFT)
     {
@@ -171,18 +170,20 @@ void up_enable_irq(int irq)
   else if (irq >= MPFS_IRQ_EXT_START)
     {
       extirq = irq - MPFS_IRQ_EXT_START;
-
-      /* Set enable bit for the irq */
-
-      uintptr_t iebase = mpfs_plic_get_iebase(up_cpu_index());
-
-      if (0 <= extirq && extirq <= NR_IRQS - MPFS_IRQ_EXT_START)
-        {
-          modifyreg32(iebase + (4 * (extirq / 32)), 0, 1 << (extirq % 32));
-        }
-      else
+      if (extirq < 0 || extirq > NR_IRQS - MPFS_IRQ_EXT_START)
         {
           PANIC();
+        }
+
+      /* Enable the irq on all harts */
+
+      for (i = 0; i < CONFIG_SMP_NCPUS; i++)
+        {
+          uintptr_t iebase = mpfs_plic_get_iebase(riscv_cpuid_to_hartid(i));
+
+          /* Set enable bit for the irq */
+
+          modifyreg32(iebase + (4 * (extirq / 32)), 0, 1 << (extirq % 32));
         }
     }
 }


### PR DESCRIPTION
## Summary

This removes several error conditions that can be present after a failed
i2c transaction. The most important of them is the priv->sem_isr semaphore
which can be signaled due to a race condition.

This also ensures the i2c device itself is in idle state before futzing
around with it.

## Impact

MPFS target, i2c driver only

## Testing

MPFS

