### PR TITLE
Mpfs reset with wdt after failed ddr training

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ddr.c
+++ b/arch/risc-v/src/mpfs/mpfs_ddr.c
@@ -3941,19 +3941,31 @@ static int mpfs_ddr_setup(struct mpfs_ddr_priv_s *priv)
 int mpfs_ddr_init(void)
 {
   struct mpfs_ddr_priv_s *priv = &g_mpfs_ddr_priv;
+  int retry_count = 20;
   int ddr_status;
 
-  /* On -EAGAIN, the whole training is restarted from the very beginning */
+  /* Restart training until it passes or retry_count reaches 0.
+   * Errors which return -EAGAIN are known to be always
+   * recoverable by controller reset; don't count these errors.
+   * Only count errors which return -EIO; they are typically recoverable.
+   * If they persist, however, eventually return failure, leading to
+   * re-trying after full reset.
+   */
 
   do
     {
       ddr_status = mpfs_ddr_setup(priv);
-      if (ddr_status == -EAGAIN)
+      if (ddr_status != OK)
         {
           mpfs_ddr_fail(priv);
         }
+
+      if (ddr_status != -EAGAIN)
+        {
+          retry_count--;
+        }
     }
-  while (ddr_status == -EAGAIN);
+  while (ddr_status != OK && retry_count > 0);
 
   if (ddr_status == 0)
     {

--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -35,6 +35,7 @@
 #include "mpfs_cache.h"
 #include "mpfs_mm_init.h"
 #include "mpfs_userspace.h"
+#include "hardware/mpfs_wdog.h"
 
 #include "riscv_internal.h"
 #include "riscv_percpu.h"
@@ -147,7 +148,15 @@ void __mpfs_start(uint64_t mhartid)
       /* Reset, but let the progress come out of the uart first */
 
       up_udelay(1000);
-      up_systemreset();
+
+      /* Reset by triggering WDOG */
+
+      putreg32(WDOG_FORCE_IMMEDIATE_RESET,
+               MPFS_WDOG0_LO_BASE + MPFS_WDOG_FORCE_OFFSET);
+
+      /* Wait for the reset */
+
+      for (; ; );
     }
 #endif
 


### PR DESCRIPTION
Refining DDR training:
- Reset with WDT after completely failed training to avoid leaving "soft reset" status in the boot reason register
- Avoid unnecessary resets after failed DDR training. In most cases it is enough to reset the controller and try again. The expected failures return -EAGAIN. But also the unexpected ones typically can be re-covered by just re-training. So always re-try the ddr training after a failure, but add a re-try counter counting only the unexpected errors, just as a backup.


