### PR TITLE
arch/risc-v/src/mpfs/mpfs_ethernet.c: Fix compilation with CONFIG_DEBUG_NET

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -2231,7 +2231,8 @@ static int mpfs_phyfind(struct mpfs_ethmac_s *priv, uint8_t *phyaddr)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG_NET) && defined(CONFIG_DEBUG_INFO)
+#if defined(CONFIG_DEBUG_NET) && defined(CONFIG_DEBUG_INFO) && \
+  defined(ETH_HAS_MDIO_PHY)
 static void mpfs_phydump(struct mpfs_ethmac_s *priv)
 {
   uint16_t phyval;
@@ -2586,6 +2587,8 @@ static void mpfs_linkspeed(struct mpfs_ethmac_s *priv)
 
   mac_putreg(priv, NETWORK_CONFIG, regval);
   mac_putreg(priv, NETWORK_CONTROL, ncr);
+
+  mpfs_phydump(priv);
 }
 #endif
 


### PR DESCRIPTION

- Fix compilation failure "error: 'mpfs_phydump' defined but not used [-Werror=unused-function]"
- Add debug dump of phy registers.
