### PR TITLE
Coremmc multiblock support

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -416,8 +416,6 @@ config MPFS_EMMCSD
 	select ARCH_HAVE_SDIO
 	select SDIO_BLOCKSETUP
 	select SDIO_DMA
-	select FAT_DMAMEMORY
-	select FAT_FORCE_INDIRECT
 	select GRAN
 	default n
 	---help---

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -123,7 +123,7 @@
 
 /* Clocks and timing */
 
-#define MPFS_FPGA_FIC0_CLK                 (50000000)
+#define MPFS_FPGA_FIC0_CLK                 (125000000)
 
 #define COREMMC_CMDTIMEOUT                 (100000)
 #define COREMMC_LONGTIMEOUT                (100000000)
@@ -1070,6 +1070,11 @@ static sdio_capset_t mpfs_capabilities(struct sdio_dev_s *dev)
   if (priv->onebit)
     {
       caps |= SDIO_CAPS_1BIT_ONLY;
+    }
+
+  if ((getreg8(MPFS_COREMMC_VR) >> 2) & 3)
+    {
+      caps |= SDIO_CAPS_4BIT;
     }
 
   return caps;

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -252,7 +252,7 @@ struct mpfs_dev_s g_coremmc_dev =
 
 /* Not all requests are 32-bit aligned, use a spare buffer workaround */
 
-static uint32_t g_aligned_buffer[512 / 4];
+static uint32_t g_aligned_buffer[4096 / 4];
 
 /****************************************************************************
  * Private Functions

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -989,7 +989,7 @@ static bool mpfs_device_reset(struct sdio_dev_s *dev)
 
   /* Store fifo size for later to check no fifo overruns occur */
 
-  fifo_size = ((getreg8(MPFS_COREMMC_VR) >> 2) & 0x3);
+  fifo_size = ((getreg8(MPFS_COREMMC_VR) >> 4) & 0x3);
   if (fifo_size == 0)
     {
       priv->fifo_depth = 512;


### PR DESCRIPTION
## Summary

Improve write performance of coremmc sdio driver by enabling multiblock transfer.

## Impact

Multiblock transfer requires CONFIG_MMCSD_MULTIBLOCK_LIMIT to be defined according to coremmc
internal buffer size. The unaligned user buffer handling limits the block count to 8 due to 4K aligned buffer.

Because FAT_DMAMEMORY and FAT_FORCE_INDIRECT feature flags are disabled to enable multiblock transfer the emmcsd sdio driver shall also handle unaligned transfer buffer.