### PR TITLE
Coremmc performance workaround

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -442,6 +442,12 @@ config MPFS_COREMMC_IRQNUM
 	range 0 63
 	depends on MPFS_COREMMC
 
+config MPFS_FPGA_FIC0_CLK_FREQ
+	int "FIC0 clk freq"
+	default 125000000
+	---help---
+		Frequency of FPGA FIC0 clock.
+
 config MPFS_TAMPER
 	bool "Tamper detection"
 	default n

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -123,7 +123,7 @@
 
 /* Clocks and timing */
 
-#define MPFS_FPGA_FIC0_CLK                 (50000000)
+#define MPFS_FPGA_FIC0_CLK                 (125000000)
 
 #define COREMMC_CMDTIMEOUT                 (100000)
 #define COREMMC_LONGTIMEOUT                (100000000)
@@ -989,7 +989,7 @@ static bool mpfs_device_reset(struct sdio_dev_s *dev)
 
   /* Store fifo size for later to check no fifo overruns occur */
 
-  fifo_size = ((getreg8(MPFS_COREMMC_VR) >> 2) & 0x3);
+  fifo_size = ((getreg8(MPFS_COREMMC_VR) >> 4) & 0x3);
   if (fifo_size == 0)
     {
       priv->fifo_depth = 512;
@@ -1070,6 +1070,11 @@ static sdio_capset_t mpfs_capabilities(struct sdio_dev_s *dev)
   if (priv->onebit)
     {
       caps |= SDIO_CAPS_1BIT_ONLY;
+    }
+
+  if (((getreg8(MPFS_COREMMC_VR) >> 2) & 3) == 0x01)
+    {
+      caps |= SDIO_CAPS_4BIT;
     }
 
   return caps;

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -123,7 +123,7 @@
 
 /* Clocks and timing */
 
-#define MPFS_FPGA_FIC0_CLK                 (125000000)
+#define MPFS_FPGA_FIC0_CLK                 (CONFIG_MPFS_FPGA_FIC0_CLK_FREQ)
 
 #define COREMMC_CMDTIMEOUT                 (100000)
 #define COREMMC_LONGTIMEOUT                (100000000)

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -1337,16 +1337,6 @@ static int mpfs_sendcmd(struct sdio_dev_s *dev, uint32_t cmd,
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   uint32_t cmdidx;
 
-  mpfs_reset_lines(priv);
-
-  /* Check if command / data lines are busy */
-
-  if (mpfs_check_lines_busy(priv))
-    {
-      mcerr("Busy!\n");
-      return -EBUSY;
-    }
-
   /* Clear all status interrupts */
 
   mpfs_putreg8(priv, COREMMC_ALL_ICR, MPFS_COREMMC_ICR);


### PR DESCRIPTION
## Summary

For Flat build poll lines_busy loop only short time at once and sleep for one system tick between checks if still busy.
Bus width and Fiq0 clock fixed.

## Impact

This workaround is needed because coremmc does not have Transfer Completed interrupt, but the BUSY state shall be read from status register by polling. Just running in busy loop would cause very high cpuload by thread using the write operation of coremmc.
