### PR TITLE
risc-v/mpfs: corespi: fix 16-bit dma transfer

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corespi.c
+++ b/arch/risc-v/src/mpfs/mpfs_corespi.c
@@ -124,6 +124,9 @@
 #define MPFS_DMA_RX_IRQ    (1 << 0)
 #define MPFS_DMA_TX_IRQ    (1 << 1)
 
+#define MPFS_DMA_CNF_IRQ_ENABLE  (1 << 0)
+#define MPFS_DMA_CNF_ENDIAN_SWAP (1 << 1)
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -1100,6 +1103,11 @@ static uint32_t mpfs_spi_dma_exchange(struct mpfs_spi_priv_s *priv,
 {
   uint32_t status;
 
+  if (priv->nbits == 16)
+    {
+      nwords *= 2;
+    }
+
   if (nwords >= MPFS_DMA_BUF_SIZE)
     {
       spierr("Transfer size too long! %zu (max: %u)\n", nwords,
@@ -1122,7 +1130,21 @@ static uint32_t mpfs_spi_dma_exchange(struct mpfs_spi_priv_s *priv,
   putreg32(nwords, MPFS_DMA_RX_BTT);  /* RX bytes to transfer */
   putreg32(nwords, MPFS_DMA_TX_BTT);  /* TX bytes to transfer */
 
-  putreg32(1, MPFS_DMA_RX_CNF);       /* IRQ enable */
+  if (priv->nbits == 16)
+    {
+      /* RX IRQ enable and endian swap */
+
+      putreg32(MPFS_DMA_CNF_IRQ_ENABLE | MPFS_DMA_CNF_ENDIAN_SWAP,
+               MPFS_DMA_RX_CNF);
+      putreg32(MPFS_DMA_CNF_ENDIAN_SWAP, MPFS_DMA_TX_CNF);
+    }
+  else
+    {
+      /* RX IRQ enable only */
+
+      putreg32(MPFS_DMA_CNF_IRQ_ENABLE, MPFS_DMA_RX_CNF);
+      putreg32(0, MPFS_DMA_TX_CNF);
+    }
 
   /* Copy TX data into area DMA can handle */
 


### PR DESCRIPTION
16-bit DMA transfer was of incomplete size. Also the endian was wrong.


