### PR TITLE
mpfs_irq.c: Interrupt claim must be cleared before disabling the source

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -131,13 +131,22 @@ void up_disable_irq(int irq)
           uintptr_t claim_address =
             mpfs_plic_get_claimbase(riscv_cpuid_to_hartid(i));
 
+          /* Clear any already claimed IRQ (this must be done BEFORE
+           * disabling the interrupt source):
+           *
+           * To signal the completion of executing an interrupt handler, the
+           * processor core writes the received interrupt ID to the
+           * Claim/Complete register. The PLIC does not check whether the
+           * completion ID is the same as the last claim ID for that target.
+           * If the completion ID does not match an interrupt source that is
+           * currently enabled for the target, the completion is ignored.
+           */
+
+          putreg32(extirq, claim_address);
+
           /* Clear enable bit for the irq */
 
           modifyreg32(iebase + (4 * (extirq / 32)), 1 << (extirq % 32), 0);
-
-          /* Clear any already claimed IRQ */
-
-          putreg32(extirq, claim_address);
         }
     }
 }


### PR DESCRIPTION
## Summary

From Polarfire SoC TRM:

6.5.8 Interrupt Completion

To signal the completion of executing an interrupt handler, the processor core writes the received interrupt ID to the Claim/Complete register. The PLIC does not check whether the completion ID is the same as the last claim ID for that target. If the completion ID does not match an interrupt source that is currently enabled for the target, the completion is ignored.

The last paragraph clearly states that IRQ completion does not work for sources that have been disabled -> must ACK the completion before disable.

## Impact

This fixes interrupt handling on MPFS.

## Testing

MPFS
