### PR TITLE
Revert "drivers/mmcsd/mmcsd_sdio.c: If CONFIG_MMCSD_SDIOWAIT_WRCOMPLE…

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -1320,11 +1320,6 @@ static int mmcsd_transferready(FAR struct mmcsd_state_s *priv)
     {
       ferr("ERROR: mmcsd_eventwait for transfer ready failed: %d\n", ret);
     }
-  else
-    {
-      priv->wrbusy = false;
-      return OK;
-    }
 #endif
 
   starttime = clock_systime_ticks();


### PR DESCRIPTION
Reverted commit seemed to cause coremmc waitresponse timeout errors.