### PR TITLE
Revert "drivers/serial/cdcacm: Reduce one copy of data between serial…

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -233,21 +233,21 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
   int nexthead;
   int ret;
 
+  /* Increment to see what the next head pointer will be.
+   * We need to use the "next" head pointer to determine when the circular
+   *  buffer would overrun
+   */
+
+  nexthead = dev->xmit.head + 1;
+  if (nexthead >= dev->xmit.size)
+    {
+      nexthead = 0;
+    }
+
   /* Loop until we are able to add the character to the TX buffer. */
 
   for (; ; )
     {
-      /* Increment to see what the next head pointer will be.
-       * We need to use the "next" head pointer to determine when the
-       * circular buffer would overrun
-       */
-
-      nexthead = dev->xmit.head + 1;
-      if (nexthead >= dev->xmit.size)
-        {
-          nexthead = 0;
-        }
-
       /* Check if the TX buffer is full */
 
       if (nexthead != dev->xmit.tail)

--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -432,6 +432,8 @@ menuconfig CDCACM
 	bool "USB Modem (CDC/ACM) support"
 	default n
 	select SERIAL_REMOVABLE
+	select SERIAL_TXDMA
+	select SERIAL_RXDMA
 	---help---
 		Enables USB Modem (CDC/ACM) support
 
@@ -679,6 +681,28 @@ config CDCACM_BULKIN_REQLEN
 		There is also no reason from CDCACM_BULKIN_REQLEN to be greater
 		than CDCACM_TXBUFSIZE-1, since a request larger than the TX
 		buffer can never be sent.
+
+config CDCACM_RXBUFSIZE
+	int "Receive buffer size"
+	default 513 if USBDEV_DUALSPEED
+	default 257 if !USBDEV_DUALSPEED
+	---help---
+		Size of the serial receive buffers.  The actual amount of data that
+		can be held in the buffer is this number minus one due to the way
+		that the circular buffer is managed.  So an RX buffer size of 257
+		will hold four full-speed, 64 byte packets; a buffer size of 513
+		will hold one high-speed, 512 byte packet.
+
+config CDCACM_TXBUFSIZE
+	int "Transmit buffer size"
+	default 769 if USBDEV_DUALSPEED
+	default 193 if !USBDEV_DUALSPEED
+	---help---
+		Size of the serial transmit buffers.  The actual amount of data that
+		can be held in the buffer is this number minus one due to the way
+		that the circular buffer is managed.  So a TX buffer size of 769
+		will hold one request of size 768; a buffer size of 193 will hold
+		two requests of size 96 bytes.
 
 if !CDCACM_COMPOSITE
 

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -157,7 +157,7 @@
 #endif
 
 #if CONFIG_MM_DEFAULT_ALIGNMENT == 0
-#  define MM_ALIGN       sizeof(uintptr_t)
+#  define MM_ALIGN       (2 * sizeof(uintptr_t))
 #else
 #  define MM_ALIGN       CONFIG_MM_DEFAULT_ALIGNMENT
 #endif

--- a/include/nuttx/usb/cdcacm.h
+++ b/include/nuttx/usb/cdcacm.h
@@ -87,6 +87,8 @@
  *   The product ID code/string. Default 0xa4a7 and "CDC/ACM Serial"
  *   0xa4a7 was selected for compatibility with the Linux CDC ACM
  *   default PID.
+ * CONFIG_CDCACM_RXBUFSIZE and CONFIG_CDCACM_TXBUFSIZE
+ *   Size of the serial receive/transmit buffers. Default 256.
  */
 
 /* Information needed in usbdev_devinfo_s */
@@ -202,6 +204,16 @@
 
 #ifndef CONFIG_CDCACM_NRDREQS
 #  define CONFIG_CDCACM_NRDREQS 4
+#endif
+
+/* TX/RX buffer sizes */
+
+#ifndef CONFIG_CDCACM_RXBUFSIZE
+#  define CONFIG_CDCACM_RXBUFSIZE 256
+#endif
+
+#ifndef CONFIG_CDCACM_TXBUFSIZE
+#  define CONFIG_CDCACM_TXBUFSIZE 256
 #endif
 
 /* Vendor and product IDs and strings.  The default is the Linux Netchip

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -62,7 +62,7 @@ config MM_KERNEL_HEAPSIZE
 
 config MM_DEFAULT_ALIGNMENT
 	int "Memory default alignment in bytes"
-	default 8
+	default 0
 	range 0 64
 	---help---
 		The memory default alignment in bytes, if this value is 0, the real


### PR DESCRIPTION
… and cdcacm framework"

This reverts commit c497c5feb01c39d20c6a34209679ec719c2e2b43.



I don't want to debug this any more, just reverting it fixes the cdcacm.
