### PR TITLE
arch/risc-v/mpfs: Remove big kernel lock from several drivers

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
@@ -417,6 +417,7 @@ union wb_u
 
 struct mpfs_rqhead_s
 {
+  spinlock_t            qlock;         /* Lock to protect access to the queue */
   struct mpfs_req_s     *head;         /* Requests are added to the head of the list */
   struct mpfs_req_s     *tail;         /* Requests are removed from the tail of the list */
 };
@@ -425,6 +426,7 @@ struct mpfs_ep_s
 {
   struct usbdev_ep_s    ep;           /* Standard endpoint structure */
 
+  spinlock_t            eplock;       /* Lock for endpoint access */
   struct mpfs_usbdev_s  *dev;         /* Reference to private driver data */
   struct mpfs_rqhead_s  reqq;         /* Read/write request queue */
   struct mpfs_rqhead_s  pendq;        /* Write requests pending stall sent */
@@ -454,6 +456,10 @@ struct mpfs_usbdev_s
   /* The bound device class driver */
 
   struct usbdevclass_driver_s *driver;
+
+  /* Device specific fields */
+
+  spinlock_t           lock;          /* Device lock */
 
   /* USB-specific fields */
 

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -251,6 +251,7 @@ struct mpfs_dev_s g_coremmc_dev =
   },
   .hw_base           = CONFIG_MPFS_COREMMC_BASE,
   .plic_irq          = MPFS_IRQ_FABRIC_F2H_0 + CONFIG_MPFS_COREMMC_IRQNUM,
+  .lock              = SP_UNLOCKED,
 #ifdef CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE
   .wrcomplete_irq    = MPFS_IRQ_FABRIC_F2H_0 +
                        CONFIG_MPFS_COREMMC_WRCOMPLETE_IRQNUM,
@@ -484,7 +485,7 @@ static void mpfs_configwaitints(struct mpfs_dev_s *priv, uint32_t waitmask,
    * operation.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
 
 #ifdef CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE
   if ((waitevents & SDIOWAIT_WRCOMPLETE) != 0)
@@ -501,7 +502,7 @@ static void mpfs_configwaitints(struct mpfs_dev_s *priv, uint32_t waitmask,
   priv->wkupevent  = wkupevent;
   priv->waitmask   = waitmask;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -525,12 +526,9 @@ static void mpfs_configxfrints(struct mpfs_dev_s *priv, uint32_t xfrmask,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   priv->xfrmask = xfrmask;
   priv->xfr_blkmask = xfr_blkmask;
-
-  mcinfo("Mask: %08" PRIx32 "\n", priv->xfrmask | priv->waitmask);
-  mcinfo("blkmask: %08" PRIx32 "\n", priv->xfr_blkmask);
 
   mpfs_putreg8(priv, priv->xfrmask | priv->waitmask, MPFS_COREMMC_IMR);
 
@@ -543,7 +541,7 @@ static void mpfs_configxfrints(struct mpfs_dev_s *priv, uint32_t xfrmask,
       mpfs_putreg8(priv, priv->xfr_blkmask, MPFS_COREMMC_SBIMR);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -2347,7 +2345,7 @@ void mpfs_coremmc_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
 
   /* Update card status */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   cdstatus = priv->cdstatus;
   if (cardinslot)
     {
@@ -2358,7 +2356,7 @@ void mpfs_coremmc_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
       priv->cdstatus &= ~SDIO_STATUS_PRESENT;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   mcinfo("cdstatus OLD: %02" PRIx8 " NEW: %02" PRIx8 "\n",
          cdstatus, priv->cdstatus);
@@ -2394,7 +2392,7 @@ void mpfs_coremmc_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
 
   /* Update card status */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   if (wrprotect)
     {
       priv->cdstatus |= SDIO_STATUS_WRPROTECTED;
@@ -2404,7 +2402,5 @@ void mpfs_coremmc_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
       priv->cdstatus &= ~SDIO_STATUS_WRPROTECTED;
     }
 
-  mcinfo("cdstatus: %02" PRIx8 "\n", priv->cdstatus);
-
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -405,6 +405,7 @@ struct mpfs_dev_s g_emmcsd_dev =
   },
   .hw_base           = MPFS_EMMC_SD_BASE,
   .plic_irq          = MPFS_IRQ_MMC_MAIN,
+  .lock              = SP_UNLOCKED,
 #ifdef CONFIG_MPFS_EMMCSD_MUX_EMMC
   .emmc              = true,
 #else
@@ -616,13 +617,13 @@ static void mpfs_configwaitints(struct mpfs_dev_s *priv, uint32_t waitmask,
    * operation.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
 
   priv->waitevents = waitevents;
   priv->wkupevent  = wkupevent;
   priv->waitmask   = waitmask;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -644,14 +645,12 @@ static void mpfs_configxfrints(struct mpfs_dev_s *priv, uint32_t xfrmask)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   priv->xfrmask = xfrmask;
-
-  mcinfo("Mask: %08" PRIx32 "\n", priv->xfrmask | priv->waitmask);
 
   putreg32(priv->xfrmask | priv->waitmask, MPFS_EMMCSD_SRS14);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -1408,7 +1407,6 @@ static void mpfs_emmc_card_init(struct mpfs_dev_s *priv)
 static bool mpfs_device_reset(struct sdio_dev_s *dev)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
-  irqstate_t flags;
   uint32_t regval;
   uint32_t cap;
 #ifdef CONFIG_MPFS_EMMCSD_CD
@@ -1416,8 +1414,6 @@ static bool mpfs_device_reset(struct sdio_dev_s *dev)
 #endif
   bool retval = true;
   int status = MPFS_EMMCSD_INITIALIZED;
-
-  flags = enter_critical_section();
 
   up_disable_irq(priv->plic_irq);
 
@@ -1646,8 +1642,6 @@ static bool mpfs_device_reset(struct sdio_dev_s *dev)
   priv->widebus    = false;
 
   mpfs_reset_lines(priv);
-
-  leave_critical_section(flags);
 
   return retval;
 }
@@ -2773,7 +2767,6 @@ static sdio_eventset_t mpfs_eventwait(struct sdio_dev_s *dev)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   sdio_eventset_t wkupevent = 0;
-  irqstate_t flags;
   int ret;
 
 #if defined(CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE)
@@ -2793,8 +2786,6 @@ static sdio_eventset_t mpfs_eventwait(struct sdio_dev_s *dev)
    * we get here.  In this case waitevents will be zero, but wkupevents will
    * be non-zero (and, hopefully, the semaphore count will also be non-zero.
    */
-
-  flags = enter_critical_section();
 
   DEBUGASSERT(priv->waitevents != 0 || priv->wkupevent != 0);
 
@@ -2843,7 +2834,6 @@ static sdio_eventset_t mpfs_eventwait(struct sdio_dev_s *dev)
 errout_with_waitints:
   mpfs_configwaitints(priv, 0, 0, 0);
 
-  leave_critical_section(flags);
   return wkupevent;
 }
 
@@ -3064,7 +3054,7 @@ void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
 
   /* Update card status */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   cdstatus = priv->cdstatus;
   if (cardinslot)
     {
@@ -3075,7 +3065,7 @@ void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
       priv->cdstatus &= ~SDIO_STATUS_PRESENT;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   mcinfo("cdstatus OLD: %02" PRIx8 " NEW: %02" PRIx8 "\n",
          cdstatus, priv->cdstatus);
@@ -3111,7 +3101,7 @@ void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
 
   /* Update card status */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   if (wrprotect)
     {
       priv->cdstatus |= SDIO_STATUS_WRPROTECTED;
@@ -3121,7 +3111,5 @@ void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
       priv->cdstatus &= ~SDIO_STATUS_WRPROTECTED;
     }
 
-  mcinfo("cdstatus: %02" PRIx8 "\n", priv->cdstatus);
-
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }

--- a/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
+++ b/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
@@ -29,6 +29,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/sdio.h>
+#include <nuttx/spinlock.h>
 #include <stdbool.h>
 #include <sys/types.h>
 
@@ -48,6 +49,7 @@ struct mpfs_dev_s
   const int wrcomplete_irq; /* Card write complete interrupt */
 #endif
   bool clk_enabled;        /* Clk state */
+  spinlock_t lock;         /* Lock for device access */
 
   /* eMMC / SD and HW parameters */
 


### PR DESCRIPTION
## Summary

This replaces the big kernel lock (enter/leave_critical_section()) with local spinlocks from all MPFS drivers that still use it. The reason is obviously to alleviate big kernel lock congestion which has a massive performance impact in SMP:

## Impact

Only the MPFS target is impacted.
App impact: No
Doc impact: No
Build system impact: No

## Testing

Tested with private downstream MPFS target that uses all of the changed drivers.

