### PR TITLE
mpfs/mpfs_emmcsd.c: ignore WRCOMPLETE

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -2776,6 +2776,17 @@ static sdio_eventset_t mpfs_eventwait(struct sdio_dev_s *dev)
   irqstate_t flags;
   int ret;
 
+#if defined(CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE)
+  if ((priv->waitevents & SDIOWAIT_WRCOMPLETE) != 0)
+    {
+      /* Do not wait for SDIOWAIT_WRCOMPLETE as the SDIOWAIT_TRANSFERDONE
+       * event has already taken care of that part also.
+       */
+
+      return SDIOWAIT_WRCOMPLETE;
+    }
+#endif
+
   mcinfo("wait\n");
 
   /* There is a race condition here... the event may have completed before


### PR DESCRIPTION
Do not wait for SDIOWAIT_WRCOMPLETE as the SDIOWAIT_TRANSFERDONE event has already taken care of both "transfer done" and "write complete" parts.

