### PR TITLE
nuttx/atomic.h: Define atomic_load as atomic_read

### DIFF
--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -104,6 +104,8 @@ typedef volatile int64_t atomic64_t;
 #define atomic64_read(obj)                    ATOMIC_FUNC(load, 8)(obj, __ATOMIC_RELAXED)
 #define atomic64_read_acquire(obj)            ATOMIC_FUNC(load, 8)(obj, __ATOMIC_ACQUIRE)
 
+#define atomic_load atomic_read
+
 #define atomic_fetch_add_acquire(obj, val)    ATOMIC_FUNC(fetch_add, 4)(obj, val, __ATOMIC_ACQUIRE)
 #define atomic_fetch_add_release(obj, val)    ATOMIC_FUNC(fetch_add, 4)(obj, val, __ATOMIC_RELEASE)
 #define atomic_fetch_add_relaxed(obj, val)    ATOMIC_FUNC(fetch_add, 4)(obj, val, __ATOMIC_RELAXED)


### PR DESCRIPTION
They are the same thing, and now atomic_load is missing entirely when LIBC_ARCH_ATOMIC is set.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


