### PR TITLE
mpfs/mpfs_entrypoints.c: Change atomic_load > atomic_read

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_entrypoints.c
+++ b/arch/risc-v/src/mpfs/mpfs_entrypoints.c
@@ -270,7 +270,7 @@ bool mpfs_get_use_sbi(uint64_t hartid)
 
 int mpfs_cpus_booted(void)
 {
-  return atomic_load(&g_cpus_booted);
+  return atomic_read(&g_cpus_booted);
 }
 
 #endif /* CONFIG_MPFS_BOOTLOADER */


### PR DESCRIPTION
Otherwise we get an undefined symbol error when LIBC_ARCH_ATOMIC is defined.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


