### PR TITLE
arch/mpfs/usb: Align usb_ctrlreq_s properly to 32-bit boundary

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
@@ -463,6 +463,7 @@ struct mpfs_usbdev_s
 
   /* USB-specific fields */
 
+  aligned_data(4)
   struct usb_ctrlreq_s ctrl;          /* Last EP0 request */
   uint8_t              devstate;      /* State of the device (see enum mpfs_devstate_e) */
   uint8_t              prevstate;     /* Previous state of the device before SUSPEND */


### PR DESCRIPTION
The alignment of the ctrlreq was correct by luck, and was broken when the spinlock was added to the structure.

For the CONFIG_BUILD_FLAT with no smp, when the spinlock_t is 8 bits.

