### PR TITLE
mpfs_corepwmc.c: Fix release of reset

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corepwm.c
+++ b/arch/risc-v/src/mpfs/mpfs_corepwm.c
@@ -760,8 +760,8 @@ static int pwm_init(struct mpfs_pwmtimer_s *priv)
 {
   /* Toggle peripheral reset */
 
-  mpfs_set_reset(MPFS_RCC_I2C, priv->pwmid, 1);
-  mpfs_set_reset(MPFS_RCC_I2C, priv->pwmid, 0);
+  mpfs_set_reset(MPFS_RCC_PWM, priv->pwmid, 1);
+  mpfs_set_reset(MPFS_RCC_PWM, priv->pwmid, 0);
 
   /* Release FIC reset and enable clocks */
 


### PR DESCRIPTION
## Summary

Releasing the I2C reset does nothing for PWM; try releasing PWM reset instead.

## Impact

MPFS PWM functionality only. Nothing else is impacted.

## Testing

Downstream MPFS target with PWM output
