### PR TITLE
mpfs_emmcsd/coremmc.c: Check if received state interrupt in SMP mode

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
@@ -417,7 +417,6 @@ union wb_u
 
 struct mpfs_rqhead_s
 {
-  spinlock_t            qlock;         /* Lock to protect access to the queue */
   struct mpfs_req_s     *head;         /* Requests are added to the head of the list */
   struct mpfs_req_s     *tail;         /* Requests are removed from the tail of the list */
 };
@@ -426,7 +425,6 @@ struct mpfs_ep_s
 {
   struct usbdev_ep_s    ep;           /* Standard endpoint structure */
 
-  spinlock_t            eplock;       /* Lock for endpoint access */
   struct mpfs_usbdev_s  *dev;         /* Reference to private driver data */
   struct mpfs_rqhead_s  reqq;         /* Read/write request queue */
   struct mpfs_rqhead_s  pendq;        /* Write requests pending stall sent */
@@ -456,10 +454,6 @@ struct mpfs_usbdev_s
   /* The bound device class driver */
 
   struct usbdevclass_driver_s *driver;
-
-  /* Device specific fields */
-
-  spinlock_t           lock;          /* Device lock */
 
   /* USB-specific fields */
 

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -986,6 +986,20 @@ static int mpfs_emmcsd_interrupt(int irq, void *context, void *arg)
 
   DEBUGASSERT(priv != NULL);
 
+#ifdef CONFIG_SPINLOCK
+  spin_lock(&priv->lock);
+
+  /* Check if any of the interrupt sources are even enabled */
+
+  if (priv->xfrmask == 0 && priv->waitmask == 0 && priv->xfr_blkmask == 0)
+    {
+      spin_unlock(&priv->lock);
+      return OK;
+    }
+
+  spin_unlock(&priv->lock);
+#endif
+
   status = getreg32(MPFS_EMMCSD_SRS12);
 
   mcinfo("status: %08" PRIx32 "\n", status);

--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -3444,6 +3444,10 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
   uint16_t pending_tx_ep;
   int i;
 
+#ifdef CONFIG_SMP
+  irqstate_t flags = enter_critical_section();
+#endif
+
   /* Get the device interrupts */
 
   isr = getreg8(MPFS_USB_IRQ);
@@ -3469,6 +3473,9 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
       priv->usbdev.dualspeed = 1;
 #endif
 
+#ifdef CONFIG_SMP
+      leave_critical_section(flags);
+#endif
       return OK;
     }
 
@@ -3553,6 +3560,9 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
       mpfs_resume(priv);
     }
 
+#ifdef CONFIG_SMP
+  leave_critical_section(flags);
+#endif
   return OK;
 }
 


### PR DESCRIPTION
In SMP mode one CPU can be executing the MMC interrupt while another CPU
disables (e.g. via watchdog timeout). As it is disabled the other CPU
assumes it's safe to start configuring the device after this.

This causes a leak in the driver's private data as well as a mutual
exclusion leak on the device itself.

Fix this by aborting any triggered interrupt by checking whether it's
even enabled.