### PR TITLE
risc-v/riscv_schedulesigaction.c: Detect correctly if the tcb is currently running on this cpu

### DIFF
--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -90,7 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb)
    * to task that is currently executing on any CPU.
    */
 
-  if (tcb == this_task() && !up_interrupt_context())
+  if (tcb == g_running_tasks[this_cpu()] && !up_interrupt_context())
     {
       /* In this case just deliver the signal now.
        * REVISIT:  Signal handler will run in a critical section!


### PR DESCRIPTION

The this_task() does not return correct tcb in all cases, correct way is to check the g_running_tasks list


