### PR TITLE
sched/nxsched_select_cpu: Fix handling of TCB_FLAG_CPU_LOCKED

### DIFF
--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -518,14 +518,16 @@ static inline_function bool nxsched_add_prioritized(FAR struct tcb_s *tcb,
 }
 
 #  ifdef CONFIG_SMP
-static inline_function int nxsched_select_cpu(cpu_set_t affinity)
+static inline_function int nxsched_select_cpu(FAR struct tcb_s *btcb)
 {
+  cpu_set_t affinity;
   uint8_t minprio;
   int cpu;
   int i;
 
-  minprio = SCHED_PRIORITY_MAX;
-  cpu     = 0xff;
+  affinity = btcb->flags & TCB_FLAG_CPU_LOCKED ? btcb->cpu : btcb->affinity;
+  minprio  = SCHED_PRIORITY_MAX;
+  cpu      = 0xff;
 
   for (i = 0; i < CONFIG_SMP_NCPUS; i++)
     {

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -162,7 +162,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
   int cpu;
   int me;
 
-  cpu = nxsched_select_cpu(btcb->affinity);
+  cpu = nxsched_select_cpu(btcb);
 
   /* Get the task currently running on the CPU (may be the IDLE task) */
 

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -212,7 +212,7 @@ bool nxsched_merge_pending(void)
           return false;
         }
 
-      cpu  = nxsched_select_cpu(ALL_CPUS); /* REVISIT:  Maybe ptcb->affinity */
+      cpu  = nxsched_select_cpu(ptcb);
       rtcb = current_task(cpu);
 
       /* Loop while there is a higher priority task in the pending task list
@@ -266,7 +266,7 @@ bool nxsched_merge_pending(void)
               goto errout;
             }
 
-          cpu  = nxsched_select_cpu(ALL_CPUS); /* REVISIT:  Maybe ptcb->affinity */
+          cpu  = nxsched_select_cpu(ptcb);
           rtcb = current_task(cpu);
         }
 


### PR DESCRIPTION
This fixes an issue where a task whose CPU has been temporarily locked to its current / previous CPU still gets scheduled to another CPU, violating the promise of the flags bit.

This causes random race condition errors.