### PR TITLE
sched/affinity: Fix CPU_LOCKED functionality for some SMP calls

### DIFF
--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -130,6 +130,7 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
                   arg.need_restore = true;
 
                   tcb->flags |= TCB_FLAG_CPU_LOCKED;
+                  CPU_ZERO(&tcb->affinity);
                   CPU_SET(tcb->cpu, &tcb->affinity);
                 }
 

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -240,6 +240,7 @@ static inline void nxsched_running_setpriority(FAR struct tcb_s *tcb,
                   arg.need_restore = true;
 
                   tcb->flags |= TCB_FLAG_CPU_LOCKED;
+                  CPU_ZERO(&tcb->affinity);
                   CPU_SET(tcb->cpu, &tcb->affinity);
                 }
 

--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -161,6 +161,7 @@ void nxsched_suspend(FAR struct tcb_s *tcb)
               arg.need_restore = true;
 
               tcb->flags |= TCB_FLAG_CPU_LOCKED;
+              CPU_ZERO(&tcb->affinity);
               CPU_SET(tcb->cpu, &tcb->affinity);
             }
 

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -181,6 +181,7 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
                       arg.need_restore   = true;
 
                       stcb->flags        |= TCB_FLAG_CPU_LOCKED;
+                      CPU_ZERO(&stcb->affinity);
                       CPU_SET(stcb->cpu, &stcb->affinity);
                     }
 

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -241,6 +241,7 @@ static int nxtask_restart(pid_t pid)
           arg.need_restore = true;
 
           tcb->flags |= TCB_FLAG_CPU_LOCKED;
+          CPU_ZERO(&tcb->affinity);
           CPU_SET(tcb->cpu, &tcb->affinity);
         }
 

--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -144,6 +144,7 @@ int nxtask_terminate(pid_t pid)
       tcb_flags = dtcb->flags;
       dtcb->flags |= TCB_FLAG_CPU_LOCKED;
       affinity = dtcb->affinity;
+      CPU_ZERO(&dtcb->affinity);
       CPU_SET(dtcb->cpu, &dtcb->affinity);
 
       ret = nxsched_smp_call_single(dtcb->cpu, terminat_handler,


### PR DESCRIPTION
From upstream