### PR TITLE
Sched semaphore fix sem recover

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -240,9 +240,11 @@ static int nxsem_freecount0holder(FAR struct semholder_s *pholder,
 {
   /* When no more counts are held, remove the holder from the list.  The
    * count was decremented in nxsem_release_holder.
+   *
+   * Mutex is held only by one thread, so the holder is always freed.
    */
 
-  if (pholder->counts <= 0)
+  if (pholder->counts <= 0 || NXSEM_IS_MUTEX(sem))
     {
       nxsem_freeholder(sem, pholder);
       return 1;
@@ -442,9 +444,11 @@ static int nxsem_restoreholderprio(FAR struct semholder_s *pholder,
 
   /* Release the holder if all counts have been given up
    * before reprioritizing causes a context switch.
+   *
+   * Mutex is held only by one thread, so the holder is always freed.
    */
 
-  if (pholder->counts <= 0)
+  if (pholder->counts <= 0 || NXSEM_IS_MUTEX(sem))
     {
       nxsem_freeholder(sem, pholder);
     }

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -198,7 +198,7 @@ int nxsem_post_slow(FAR sem_t *sem)
           if (mutex)
             {
               uint32_t blocking_bit = dq_empty(SEM_WAITLIST(sem)) ?
-                NXSEM_MBLOCKING_BIT : 0;
+                0 : NXSEM_MBLOCKING_BIT;
               atomic_set(NXSEM_MHOLDER(sem),
                          ((uint32_t)stcb->pid) | blocking_bit);
             }

--- a/sched/semaphore/sem_waitirq.c
+++ b/sched/semaphore/sem_waitirq.c
@@ -101,21 +101,12 @@ void nxsem_wait_irq(FAR struct tcb_s *wtcb, int errcode)
 
   /* This restores the value to what it was before the previous sem_wait.
    * This caused the thread to be blocked in the first place.
+   *
+   * For mutexes, the holder is updated by the thread itself
+   * when it exits nxsem_wait
    */
 
-  if (mutex)
-    {
-      /* The TID of the mutex holder is correct but we need to
-       * update the blocking bit. The mutex is still blocking if there are
-       * any items left in the wait queue.
-       */
-
-      if (dq_empty(SEM_WAITLIST(sem)))
-        {
-          atomic_fetch_and(NXSEM_MHOLDER(sem), ~NXSEM_MBLOCKING_BIT);
-        }
-    }
-  else
+  if (!mutex)
     {
       atomic_fetch_add(NXSEM_COUNT(sem), 1);
     }


### PR DESCRIPTION
This PR fixes random semaphore related crashes:

- There was a bug in sem_post, setting the blocking bit wrongly
- There is a bug in removing mutex holder structures, causing randomly holder not being removed, and leaving a deleted tasks tcb in semaphore, which was then accessed in priority restoration
- There was some unnecessary code in waitirq


