### PR TITLE
[NOT UPSTREAM] assert: Remove dependency to !NDEBUG for ASSERT_FILENAME

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -682,7 +682,6 @@ config NDEBUG
 config ASSERTIONS_FILENAME
 	bool "Enable library call assert(3) show the file name"
 	default DEBUG_ASSERTIONS_FILENAME || !DEFAULT_SMALL
-	depends on !NDEBUG
 	---help---
 		This option can display the file information of the library call assert(3)
 		function when it is enabled. This option maybe will take up a lot


### PR DESCRIPTION
It is not dependent on NDEBUG at all. Userspace assert() is, but with this dependency the kernel PANIC()s don't show file/line either.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


