### PR TITLE
arch/risc-v/mpfs: Add optimized perf timer functions for mpfs

### DIFF
--- a/arch/arm/src/armv7-a/arm_perf.c
+++ b/arch/arm/src/armv7-a/arm_perf.c
@@ -31,7 +31,7 @@
 #include "arm_timer.h"
 #include "sctlr.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/arm/src/armv7-m/arm_perf.c
+++ b/arch/arm/src/armv7-m/arm_perf.c
@@ -32,7 +32,7 @@
 #include "itm.h"
 #include "nvic.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/arm/src/armv7-r/arm_perf.c
+++ b/arch/arm/src/armv7-r/arm_perf.c
@@ -31,7 +31,7 @@
 #include "arm_timer.h"
 #include "sctlr.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/arm/src/armv8-m/arm_perf.c
+++ b/arch/arm/src/armv8-m/arm_perf.c
@@ -32,7 +32,7 @@
 #include "itm.h"
 #include "nvic.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/arm/src/armv8-r/arm_perf.c
+++ b/arch/arm/src/armv8-r/arm_perf.c
@@ -30,7 +30,7 @@
 #include "arm_internal.h"
 #include "sctlr.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/arm64/src/common/arm64_perf.c
+++ b/arch/arm64/src/common/arm64_perf.c
@@ -28,7 +28,7 @@
 
 #include "arm64_pmu.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -216,7 +216,6 @@ config ARCH_CHIP_MPFS
 	select ARCH_HAVE_S_MODE
 	select ARCH_RV_CPUID_MAP
 	select ARCH_HAVE_PERF_EVENTS
-	select ARCH_PERF_EVENTS
 	select ONESHOT
 	select ALARM_ARCH
 	---help---

--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -215,6 +215,8 @@ config ARCH_CHIP_MPFS
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_S_MODE
 	select ARCH_RV_CPUID_MAP
+	select ARCH_HAVE_PERF_EVENTS
+	select ARCH_PERF_EVENTS
 	select ONESHOT
 	select ALARM_ARCH
 	---help---

--- a/arch/risc-v/src/common/riscv_perf_cycle.c
+++ b/arch/risc-v/src/common/riscv_perf_cycle.c
@@ -32,7 +32,7 @@
 
 #include "riscv_internal.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/risc-v/src/common/riscv_perf_time.c
+++ b/arch/risc-v/src/common/riscv_perf_time.c
@@ -32,7 +32,7 @@
 
 #include "riscv_internal.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_perf.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_perf.c
@@ -35,7 +35,7 @@
 #include "hardware/esp32c3_system.h"
 #include "esp32c3_clockconfig.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -35,6 +35,7 @@ CHIP_CSRCS += mpfs_lowputc.c mpfs_serial.c
 CHIP_CSRCS += mpfs_start.c mpfs_timerisr.c
 CHIP_CSRCS += mpfs_gpio.c mpfs_systemreset.c
 CHIP_CSRCS += mpfs_plic.c mpfs_dsn.c
+CHIP_CSRCS += mpfs_perf.c
 
 ifeq ($(CONFIG_MPFS_CLKINIT),y)
 CHIP_CSRCS += mpfs_clockconfig.c

--- a/arch/risc-v/src/mpfs/mpfs_perf.c
+++ b/arch/risc-v/src/mpfs/mpfs_perf.c
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_perf.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this args for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/clock.h>
+#include <nuttx/arch.h>
+
+#include <stdint.h>
+#include <time.h>
+
+#include <arch/board/board.h>
+
+#include "riscv_internal.h"
+#include "hardware/mpfs_memorymap.h"
+#include "hardware/mpfs_clint.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_perf_init
+ ****************************************************************************/
+
+void up_perf_init(void *arg)
+{
+}
+
+/****************************************************************************
+ * Name: up_perf_gettime
+ ****************************************************************************/
+
+clock_t up_perf_gettime(void)
+{
+  return getreg64(MPFS_CLINT_MTIME);
+}
+
+/****************************************************************************
+ * Name: up_perf_getfreq
+ ****************************************************************************/
+
+unsigned long up_perf_getfreq(void)
+{
+  return MPFS_MSS_RTC_TOGGLE_CLK;
+}
+
+/****************************************************************************
+ * Name: up_perf_convert
+ ****************************************************************************/
+
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
+{
+  ts->tv_sec  = elapsed / MPFS_MSS_RTC_TOGGLE_CLK;
+  elapsed    -= ts->tv_sec * MPFS_MSS_RTC_TOGGLE_CLK;
+  ts->tv_nsec = elapsed * NSEC_PER_SEC / MPFS_MSS_RTC_TOGGLE_CLK;
+}
+
+/****************************************************************************
+ * Name: up_udelay
+ *
+ * Description:
+ *   Delay for the requested number of microseconds.
+ *
+ ****************************************************************************/
+
+void up_udelay(useconds_t microseconds)
+{
+  clock_t start = up_perf_gettime();
+  clock_t end = microseconds * up_perf_getfreq() / USEC_PER_SEC + start + 1;
+  while (((sclock_t)(up_perf_gettime() - end)) < 0)
+    {
+    }
+}
+
+/****************************************************************************
+ * Name: up_ndelay
+ *
+ * Description:
+ *   Delay for the requested number of nanoseconds.
+ *
+ ****************************************************************************/
+
+void up_ndelay(unsigned long nanoseconds)
+{
+  up_udelay((nanoseconds + NSEC_PER_USEC - 1) / NSEC_PER_USEC);
+}

--- a/arch/x86_64/src/intel64/intel64_perf.c
+++ b/arch/x86_64/src/intel64/intel64_perf.c
@@ -29,7 +29,7 @@
 
 #include "x86_64_internal.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/arch/xtensa/src/common/xtensa_perf.c
+++ b/arch/xtensa/src/common/xtensa_perf.c
@@ -30,7 +30,7 @@
 #include "xtensa_counter.h"
 #include "xtensa.h"
 
-#ifdef CONFIG_ARCH_PERF_EVENTS
+#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
 
 /****************************************************************************
  * Private Data

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -351,7 +351,7 @@ int weak_function up_alarm_tick_start(clock_t ticks)
  *   units.
  ****************************************************************************/
 
-#ifndef CONFIG_ARCH_PERF_EVENTS
+#ifndef CONFIG_ARCH_HAVE_PERF_EVENTS
 void up_perf_init(FAR void *arg)
 {
   UNUSED(arg);

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -399,7 +399,7 @@ int weak_function up_timer_tick_start(clock_t ticks)
  *   units.
  ****************************************************************************/
 
-#ifndef CONFIG_ARCH_PERF_EVENTS
+#ifndef CONFIG_ARCH_HAVE_PERF_EVENTS
 void up_perf_init(FAR void *arg)
 {
   UNUSED(arg);


### PR DESCRIPTION
Add up_perf_ functions for MPFS, which don't rely on alarm/oneshot interface.

Also add optimized up_udelay and up_ndelay functions, which use the MTIMER directly to measure time; making them accurate and more multithreading frendly.
