### PR TITLE
Imx9 secure world

### DIFF
--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -72,4 +72,5 @@ Guides
   reading_can_msgs.rst
   remove_device_drivers_nsh.rst
   rust.rst
+  optee.rst
 

--- a/Documentation/guides/optee.rst
+++ b/Documentation/guides/optee.rst
@@ -1,0 +1,307 @@
+=======================
+Interfacing with OP-TEE
+=======================
+
+Overview
+========
+
+NuttX supports basic interfacing with OP-TEE OS through three different
+transports: local network, RPMsg, and native Secure Monitor Calls (SMCs)
+on arm. Tasks can interface with the OP-TEE driver (and in turn with the
+OP-TEE OS) via IOCTLs on the TEE (``/dev/tee#``) character device. This
+interface should allow use-of/integration-with libteec, although this is
+not officially supported by NuttX, and is out of the scope of this guide.
+
+The driver supports opening and closing sessions, allocating and registering
+shared memory, and invoking functions on OP-TEE Trusted Applications (TAs).
+It does not (yet) support reverse direction commands (TA -> Normal World)
+to something like a TEE supplicant.
+
+Enabling the OP-TEE Driver
+==========================
+
+The driver is enabled using one of:
+
+- ``CONFIG_DEV_OPTEE_LOCAL``
+- ``CONFIG_DEV_OPTEE_RPMSG``
+- ``CONFIG_DEV_OPTEE_SMC``
+
+All of the above require also ``CONFIG_ALLOW_BSD_COMPONENTS`` and
+``CONFIG_LIBC_MEMFD_SHMFS``, which in turn requires ``CONFIG_FS_SHMFS``. So,
+at a bare minimum, to enable the driver one would need something like the
+following:
+
+.. code-block::
+
+  CONFIG_ALLOW_BSD_COMPONENTS=y
+  CONFIG_DEV_OPTEE_SMC=y
+  CONFIG_FS_SHMFS=y
+  CONFIG_LIBC_MEMFD_SHMFS=y
+
+Each implementation (local, RPMsg, or SMC) may have further dependencies
+(e.g. RPMsg requires ``CONFIG_NET_RPMSG`` and more) and may have further
+parameters to configure (e.g. RPMsg remote CPU name through
+``CONFIG_OPTEE_REMOTE_CPU_NAME``).
+
+.. warning::
+  ``CONFIG_DEV_OPTEE_SMC`` has only been tested on arm64. Also, please note
+  that in configurations with ``CONFIG_ARM*_DCACHE_DISABLE=y`` you might
+  encounter issues with shared memory depending on the state of the data
+  cache in Secure World.
+
+Successful registration of the driver can be verified by looking into
+``/dev/tee0``. For instance, incompatibility with the TEE OS running in the
+system, will prevent the ``/dev/tee0`` character device from being
+registered.
+
+IOCTLs supported
+================
+
+All IOCTLs return negative error codes on failure. All of them return 0
+on success unless otherwise specified (see ``TEE_IOC_SHM_ALLOC``).
+
+- ``TEE_IOC_VERSION`` : Query the version and capabilities of the TEE driver.
+
+  - Use the ``struct tee_ioctl_version_data`` to get the version and
+    capabilities. This driver supports OP-TEE so you should expect to
+    receive only ``TEE_IMPL_ID_OPTEE`` in ``.impl_id`` and ``TEE_OPTEE_CAP_TZ``
+    in ``.impl_caps``. The driver is GlobalPlatform compliant, and you should
+    always expect to receive ``TEE_GEN_CAP_GP | TEE_GEN_CAP_MEMREF_NULL`` in
+    ``.gen_caps``. If using the SMC implementation, the driver supports also
+    shared memory registration, so you can expect also ``TEE_GEN_CAP_REG_MEM``
+    in ``.gen_caps``.
+
+- ``TEE_IOC_OPEN_SESSION`` :  Open a session with a Trusted Application.
+
+  - Expects a ``struct tee_ioctl_buf_data`` pointer, pointing to a
+    ``struct tee_ioctl_open_session_arg`` instance with at minimum, the ``.uuid``
+    set. You can typically use ``uuid_enc_be()`` to encode a ``uuid_t`` struct
+    to the raw byte buffer expected in the ``.uuid`` field. After a successful
+    call, you can expect to get a session identifier back in the ``.session``
+    field.
+
+- ``TEE_IOC_CLOSE_SESSION`` : Close a session with a Trusted Application.
+
+  - Expects a pointer to a ``struct tee_ioctl_close_session_arg`` with the
+    ``.session`` field set to the identifier of the session to close.
+
+- ``TEE_IOC_INVOKE`` : Invoke a function on a previously opened session to a Trusted Application.
+
+  - Expects a ``struct tee_ioctl_buf_data`` pointer, pointing to a
+    ``struct tee_ioctl_invoke_arg`` instance. You can use the
+    ``TEE_IOCTL_PARAM_SIZE()`` macro to calculate the size of the
+    variable-length array of ``struct tee_ioctl_param`` parameters in the
+    invoke arguments struct. At minimum, the interface expects the fields
+    ``.func``, ``.session``, ``.num_params``, and ``.params`` to be set.
+    ``.cancel_id`` can be optionally set to enable later canceling of this
+    command if needed.
+    You might notice that ``struct tee_ioctl_param`` has rather obscure field
+    names (``.a``, ``.b``, ``.c``). This can be improved with a union in the
+    future, but until then, please refer to ``include/nuttx/tee.h`` for details.
+    In short, for shared memory references, ``.a`` is the offset into the
+    shared memory buffer, ``.b`` is the size of the buffer, and ``.c`` is the
+    the shared memory identifier (``.addr`` field used in
+    ``TEE_IOC_SHM_REGISTER``).
+
+- ``TEE_IOC_CANCEL`` : Cancel a currently invoked command.
+
+  - Expects a ``struct tee_ioctl_cancel_arg`` pointer with the ``.session``
+    and ``.cancel_id`` fields set.
+
+- ``TEE_IOC_SHM_ALLOC`` : Allocate shared memory between the user space and the secure OS.
+
+  - Expects a ``struct tee_ioctl_shm_alloc_data`` pointer with the ``.size``
+    field set, and ignoring the ``.flags`` field. Upon successful return,
+    it returns the memory file descriptor one can use ``mmap()`` on (with
+    ``MAP_SHARED``). It also returns an identifier for the allocation
+    in ``.id``.
+
+- ``TEE_IOC_SHM_REGISTER`` : Register a shared memory reference with the secure OS.
+
+  - Expects a pointer to a ``struct tee_ioctl_shm_register_data`` instance
+    with all fields set except ``.id``. ``.flags`` can be any combination of
+    ``TEE_SHM_REGISTER`` and ``TEE_SHM_SEC_REGISTER`` but not ``TEE_SHM_ALLOC``.
+    ``TEE_SHM_REGISTER`` registers the memory with the driver for automatic
+    cleanup (not freeing!) during ``/dev/tee#`` character device close.
+    ``TEE_SHM_SEC_REGISTER`` registers the memory with the secure OS for later
+    use in memrefs and is automatically de-registered during driver close if
+    ``TEE_SHM_REGISTER`` is also specified. ``.addr`` shall point to the (user)
+    memory to register and ``.size`` shall indicate its size. The identifier
+    used to register shared memory with the secure OS is the value of the
+    ``.addr`` field (what one needs to specify in ``tee_ioctl_param.c``
+    during a ``TEE_IOC_INVOKE``).
+
+Typical usage
+=============
+
+#. Include the necessary headers:
+
+   .. code-block:: c
+
+     #include <stdio.h>
+     #include <stdlib.h>
+     #include <fcntl.h>
+     #include <unistd.h>
+     #include <errno.h>
+     #include <sys/ioctl.h>
+     #include <nuttx/tee.h>
+     #include <uuid.h>
+
+#. Open the TEE character device
+
+   .. code-block:: c
+
+     int fd = open("/dev/tee0", O_RDONLY | O_NONBLOCK);
+
+#. Check the version and capabilities
+
+   .. code-block:: c
+
+     struct tee_ioctl_version_data ioc_ver;
+
+     int ret = ioctl(fd, TEE_IOC_VERSION, (unsigned long)&ioc_ver);
+     if (ret < 0)
+       {
+         printf("Failed to query TEE driver version and caps: %d, %s\n",
+               ret, strerror(errno));
+         return ret;
+       }
+
+     [...check ioc_ver accordingly...]
+
+#. Open a session with a Trusted Application
+
+   .. code-block:: c
+
+     const uuid_t *uuid = [...];
+     struct tee_ioctl_open_session_arg ioc_opn = { 0 };
+     struct tee_ioctl_buf_data ioc_buf;
+
+     uuid_enc_be(&ioc_opn.uuid, uuid);
+
+     ioc_buf.buf_ptr = (uintptr_t)&ioc_opn;
+     ioc_buf.buf_len = sizeof(struct tee_ioctl_open_session_arg);
+
+     ret = ioctl(fd, TEE_IOC_OPEN_SESSION, (unsigned long)&ioc_buf);
+     if (ret < 0)
+       {
+         return ret;
+       }
+
+     [...use ioc_opn.session returned...]
+
+#. Invoke a function of the Trusted Application
+
+   .. code-block:: c
+
+     const size_t num_params = 1;
+     struct tee_ioctl_invoke_arg *ioc_args;
+     struct tee_ioctl_buf_data ioc_buf;
+     size_t ioc_args_len;
+
+     ioc_args_len = sizeof(struct tee_ioctl_invoke_arg) +
+                    TEE_IOCTL_PARAM_SIZE(num_params);
+
+     ioc_args = (struct tee_ioctl_invoke_arg *)calloc(1, ioc_args_len);
+     if (!ioc_args)
+       {
+         return -ENOMEM;
+       }
+
+     ioc_args->func = <SOME_FUNCTION_ID>;
+     ioc_args->session = ioc_opn.session;
+     ioc_args->num_params = num_params;
+     ioc_args->params[0].attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT;
+
+     ioc_buf.buf_ptr = (uintptr_t)ioc_args;
+     ioc_buf.buf_len = ioc_args_len;
+
+     ret = ioctl(fd, TEE_IOC_INVOKE, (unsigned long)&ioc_buf);
+     if (ret < 0)
+       {
+         goto err_with_args;
+       }
+
+     [...use result (if any) in ioc_args->params...]
+
+#. Allocate shared memory through the driver
+
+   .. code-block:: c
+
+     struct tee_ioctl_shm_alloc_data ioc_alloc = { 0 };
+     int memfd;
+     void *shm;
+
+     ioc_alloc.size = 1024;
+
+     memfd = ioctl(fd, TEE_IOC_SHM_ALLOC, (unsigned long)&ioc_alloc);
+     if (memfd < 0)
+       {
+         return memfd;
+       }
+
+     shm = mmap(NULL, ioc_alloc.size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                memfd, 0);
+     if (shm == MAP_FAILED)
+       {
+         close(memfd);
+         return -ENOMEM;
+       }
+
+#. Register shared memory with the driver and the secure OS
+
+   .. code-block:: c
+
+     /* The following will fail if TEE_GEN_CAP_REG_MEM is not reported in
+      * the returned `ioc_ver.gen_caps` in step 1 above */
+
+     struct tee_ioctl_shm_register_data ioc_reg = { 0 };
+
+     ioc_reg.addr = (uintptr_t)ptr;
+     ioc_reg.length = ioc_alloc.size;
+     ioc_reg.flags = TEE_SHM_REGISTER | TEE_SHM_SEC_REGISTER;
+
+     ret = ioctl(fd, TEE_IOC_SHM_REGISTER, (unsigned long)&ioc_reg);
+     if (ret < 0)
+       {
+         munmap(shm, ioc_alloc.size);
+         close(memfd);
+         return ret;
+       }
+
+#. Use the registered shared memory in an invocation
+
+   .. code-block:: c
+
+     const size_t num_params = 1;
+     struct tee_ioctl_invoke_arg *ioc_args;
+     struct tee_ioctl_buf_data ioc_buf;
+     size_t ioc_args_len;
+
+     ioc_args_len = sizeof(struct tee_ioctl_invoke_arg) +
+                    TEE_IOCTL_PARAM_SIZE(num_params);
+
+     ioc_args = (struct tee_ioctl_invoke_arg *)calloc(1, ioc_args_len);
+     if (!ioc_args)
+       {
+         return -ENOMEM;
+       }
+
+     ioc_args->func = <SOME_FUNCTION_ID>;
+     ioc_args->session = ioc_opn.session;
+     ioc_args->num_params = num_params;
+     ioc_args->params[0].attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT;
+     ioc_args->params[0].a = 0;
+     ioc_args->params[0].b = ioc_alloc.size;
+     ioc_args->params[0].a = (uintptr_t)shm;
+
+     ioc_buf.buf_ptr = (uintptr_t)ioc_args;
+     ioc_buf.buf_len = ioc_args_len;
+
+     ret = ioctl(fd, TEE_IOC_INVOKE, (unsigned long)&ioc_buf);
+     if (ret < 0)
+       {
+         goto err_with_args;
+       }
+
+     [...use result (if any) in ioc_args->params...]

--- a/arch/arm64/include/imx9/imx9_ahab.h
+++ b/arch/arm64/include/imx9/imx9_ahab.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * arch/arm64/include/imx9/imx9_ahab.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_INCLUDE_IMX9_IMX9_AHAB_H
+#define __ARCH_ARM64_INCLUDE_IMX9_IMX9_AHAB_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <imx_container.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ahab_auth_release
+ *
+ * Description:
+ *   Release the current container used by ELE for AHAB.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int ahab_auth_release(void);
+
+/****************************************************************************
+ * Name: ahab_read_auth_image
+ *
+ * Description:
+ *   Copy to RAM, then authenticate the image_index image of the container.
+ *
+ * Input Parameters:
+ *   container - Pointer to a copy of the AHAB container header in RAM.
+ *   image_index - The index of the image in the current container.
+ *   container_offset - Offset of the container in the boot device.
+ *
+ * Returned Value:
+ *   NULL pointer for failure, otherwise a pointer to the beginning of the
+ *   authenticated, image's header.
+ *
+ ****************************************************************************/
+
+struct boot_img_hdr *ahab_read_auth_image(struct container_hdr *container,
+                                          int image_index,
+                                          unsigned long container_offset);
+
+#endif /* __ARCH_ARM64_INCLUDE_IMX9_IMX9_AHAB_H */

--- a/arch/arm64/include/imx9/imx9_romapi.h
+++ b/arch/arm64/include/imx9/imx9_romapi.h
@@ -1,0 +1,153 @@
+/****************************************************************************
+ * arch/arm64/include/imx9/imx9_romapi.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_INCLUDE_IMX9_IMX9_ROMAPI_H
+#define __ARCH_ARM64_INCLUDE_IMX9_IMX9_ROMAPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* infor_type values for imx9_rom_api_query_boot_infor(). */
+
+#define QUERY_ROM_VER    1
+#define QUERY_BOOT_DEV   2
+#define QUERY_PAGE_SZ    3
+#define QUERY_IVT_OFF    4
+#define QUERY_BOOT_STAGE 5
+#define QUERY_IMG_OFF    6
+
+/* Native return values from ROM API. */
+
+#define  ROMAPI_INVALID_PARA         1
+#define  ROMAPI_READ_FAILURE         2
+#define  ROMAPI_DEVICE_NOT_READY     3
+#define  ROMAPI_OUT_OF_DEVICE_MEMORY 4
+#define  ROMAPI_OK                   0xf0
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Boot device types returned by ROM API (i.MX93). */
+
+enum imx9_romapi_bootdev_e
+{
+  BOOTDEV_SD           = 1,
+  BOOTDEV_MMC          = 2,
+  BOOTDEV_NAND         = 3,
+  BOOTDEV_FLEXSPI_NOR  = 4,
+  BOOTDEV_SPI_NOR      = 6,
+  BOOTDEV_FLEXSPI_NAND = 8,
+  BOOTDEV_USB          = 0xe,
+  BOOTDEV_MEM_DEV      = 0xf,
+  BOOTDEV_INVALID      = 0xff
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx9_romapi_load_image
+ *
+ * Description:
+ *   Use the i.MX9 ROM API, to copy data from the boot device to memory.
+ *
+ * Input Parameters:
+ *   dest - Copy destination.
+ *   offset - Offset from boot device to copy from.
+ *   size - Size in bytes to copy.
+ *
+ * Returned Value:
+ *   ROMAPI_OK - Success.
+ *   ROMAPI_INVALID_PARA - Invalid parameters.
+ *   ROMAPI_READ_FAILURE - Low level device read failure.
+ *   ROMAPI_DEVICE_NOT_READY - The device isn't initialized or is invalid.
+ *   ROMAPI_OUT_OF_DEVICE_MEMORY - Attempted to read data outside of the
+ *   boot device's memory.
+ *
+ ****************************************************************************/
+
+uint32_t imx9_romapi_load_image(uint8_t *dest, uint32_t offset,
+                                uint32_t size);
+
+/****************************************************************************
+ * Name: imx9_romapi_query_boot_infor
+ *
+ * Description:
+ *   Query information from the ROM API.
+ *
+ * Input Parameters:
+ *   infor_type - Type of information to query.
+ *   infor -  Points to the word to save the queried information.
+ *
+ * Returned Value:
+ *   ROMAPI_OK - Success.
+ *   ROMAPI_INVALID_PARA - Invalid parameters.
+ *
+ ****************************************************************************/
+
+uint32_t imx9_romapi_query_boot_infor(uint32_t infor_type, uint32_t *infor);
+
+/****************************************************************************
+ * Name: imx9_romapi_get_boot_device
+ *
+ * Description:
+ *   Get the boot device type.
+ *
+ * Returned Value:
+ *   The device type.
+ *
+ ****************************************************************************/
+
+enum imx9_romapi_bootdev_e imx9_romapi_get_boot_device(void);
+
+/****************************************************************************
+ * Name: imx9_romapi_get_seq_cntr_base
+ *
+ * Description:
+ *   Get the offset in bytes from the boot device of the cntr_idx container.
+ *   The containers are assumed to be sequential in the boot device's
+ *   memory.
+ *
+ * Input Parameters:
+ *   image_offset - Image offset of the first container in the boot device.
+ *   pagesize - Pagesize of the boot device.
+ *   cntr_idx - Index of the container.
+ *
+ * Returned Value:
+ *   The offset from the boot device in bytes of the cntr_idx container.
+ *   -1 is returned in case of error.
+ *
+ ****************************************************************************/
+
+int64_t imx9_romapi_get_seq_cntr_base(uint32_t image_offset,
+                                      uint32_t pagesize,
+                                      uint8_t cntr_idx);
+#endif /* __ARCH_ARM64_INCLUDE_IMX9_IMX9_ROMAPI_H */

--- a/arch/arm64/include/syscall.h
+++ b/arch/arm64/include/syscall.h
@@ -110,6 +110,50 @@
 #define ARM_SMCC_RES_A6       (6)
 #define ARM_SMCC_RES_A7       (7)
 
+#define ARM_SMCCC_STD_CALL    0UL
+#define ARM_SMCCC_FAST_CALL   1UL
+#define ARM_SMCCC_TYPE_SHIFT  31
+
+#define ARM_SMCCC_SMC_32      0
+#define ARM_SMCCC_SMC_64      1
+#define ARM_SMCCC_CALL_CONV_SHIFT 30
+
+#define ARM_SMCCC_OWNER_MASK  0x3F
+#define ARM_SMCCC_OWNER_SHIFT 24
+
+#define ARM_SMCCC_FUNC_MASK   0xFFFF
+
+#define ARM_SMCCC_IS_FAST_CALL(smc_val) \
+  ((smc_val) & (ARM_SMCCC_FAST_CALL << ARM_SMCCC_TYPE_SHIFT))
+#define ARM_SMCCC_IS_64(smc_val) \
+  ((smc_val) & (ARM_SMCCC_SMC_64 << ARM_SMCCC_CALL_CONV_SHIFT))
+#define ARM_SMCCC_FUNC_NUM(smc_val)  ((smc_val) & ARM_SMCCC_FUNC_MASK)
+#define ARM_SMCCC_OWNER_NUM(smc_val) \
+  (((smc_val) >> ARM_SMCCC_OWNER_SHIFT) & ARM_SMCCC_OWNER_MASK)
+
+#define ARM_SMCCC_CALL_VAL(type, calling_convention, owner, func_num) \
+  (((type) << ARM_SMCCC_TYPE_SHIFT) | \
+  ((calling_convention) << ARM_SMCCC_CALL_CONV_SHIFT) | \
+  (((owner) & ARM_SMCCC_OWNER_MASK) << ARM_SMCCC_OWNER_SHIFT) | \
+  ((func_num) & ARM_SMCCC_FUNC_MASK))
+
+#define ARM_SMCCC_OWNER_ARCH            0
+#define ARM_SMCCC_OWNER_CPU             1
+#define ARM_SMCCC_OWNER_SIP             2
+#define ARM_SMCCC_OWNER_OEM             3
+#define ARM_SMCCC_OWNER_STANDARD        4
+#define ARM_SMCCC_OWNER_TRUSTED_APP     48
+#define ARM_SMCCC_OWNER_TRUSTED_APP_END 49
+#define ARM_SMCCC_OWNER_TRUSTED_OS      50
+#define ARM_SMCCC_OWNER_TRUSTED_OS_END  63
+
+#define ARM_SMCCC_QUIRK_NONE            0
+#define ARM_SMCCC_QUIRK_QCOM_A6         1 /* Save/restore register a6 */
+
+#define ARM_SMCCC_ARCH_FEATURES         0x80000001
+
+#define ARM_SMCCC_RET_NOT_SUPPORTED     ((unsigned long)-1)
+
 #ifndef __ASSEMBLY__
 
 /****************************************************************************
@@ -300,10 +344,10 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
 
 /* semihosting(SMH) call with call number and one parameter */
 
-static inline long smh_call(unsigned int nbr, void *parm)
+static inline long smh_call(unsigned int nbr, void *param)
 {
   register uint64_t reg0 __asm__("x0") = (uint64_t)(nbr);
-  register uint64_t reg1 __asm__("x1") = (uint64_t)(parm);
+  register uint64_t reg1 __asm__("x1") = (uint64_t)(param);
 
   __asm__ __volatile__
   (

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -100,6 +100,13 @@ ifeq ($(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK),y)
   ARCHOPTIMIZATION += --param asan-instrument-writes=0
 endif
 
+# If we don't use MMU, all memory is treated as device memory and can't handle
+# alignment faults. Some compiler builtins like memset() can introduce
+# alignment faults. We need to disable them in that case.
+ifneq ($(CONFIG_ARCH_USE_MMU),y)
+  ARCHOPTIMIZATION += -fno-builtin
+endif
+
 # Instrumentation options
 
 ifeq ($(CONFIG_ARCH_INSTRUMENT_ALL),y)

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -195,6 +195,10 @@ if(CONFIG_DEBUG_SYMBOLS)
   add_compile_options(${CONFIG_DEBUG_SYMBOLS_LEVEL})
 endif()
 
+if(NOT CONFIG_ARCH_USE_MMU)
+  add_compile_options(-fno-builtin)
+endif()
+
 if(CONFIG_ARCH_TOOLCHAIN_GNU AND NOT CONFIG_ARCH_TOOLCHAIN_CLANG)
   if(NOT GCCVER)
     execute_process(COMMAND ${CMAKE_C_COMPILER} --version

--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -61,12 +61,12 @@ config IMX9_HAVE_ATF_FIRMWARE
 
 config IMX9_BOOTLOADER
 	bool "Bootloader"
-	select ARM64_DECODEFIQ
-	select IMX9_DDR_TRAINING
+	select ARM64_DECODEFIQ if ARCH_ARM64_EXCEPTION_LEVEL = 3
+	select IMX9_DDR_TRAINING if ARCH_ARM64_EXCEPTION_LEVEL = 3
 	default n
 	---help---
 		Configure NuttX as the bootloader. NuttX will be compiled
-		into OCRAM. It will run in EL3 secure state.
+		into OCRAM if we are in EL3.
 
 config BOOTLOADER_SYS_CLOCK
 	int "Bootloader system clock for timer"

--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -83,6 +83,30 @@ config IMX9_DDR_TRAINING
 	---help---
 		Perform DDR training to prepare the external memory for use.
 
+config IMX9_ROMAPI
+	bool "ROM API functionality"
+	depends on IMX9_BOOTLOADER
+	default n
+	---help---
+		Enable wrappers that call the on‑chip ROM API for image download
+		and boot‑information queries. Required for AHAB secure boot
+		unless an alternative generic device loader is supplied.
+
+config IMX9_AHAB_BOOT
+	bool "Support i.MX9 AHAB features"
+	depends on IMX9_BOOTLOADER
+	select IMX9_ROMAPI  # AHAB needs a loader; ROMAPI is the default
+	default n
+	---help---
+		Enable AHAB functionality
+
+config IMX_AHAB_CNTR_ADDR
+	hex "Load address of the AHAB container in RAM"
+	depends on IMX9_AHAB_BOOT
+	default 0x80000000
+	---help---
+		Physical address where the AHAB container header is loaded into memory.
+
 menu "i.MX9 Peripheral Selection"
 
 config IMX9_EDMA

--- a/arch/arm64/src/imx9/Make.defs
+++ b/arch/arm64/src/imx9/Make.defs
@@ -89,6 +89,14 @@ ifeq ($(CONFIG_IMX9_BOOTLOADER), y)
   CHIP_CSRCS += imx9_ele.c
 endif
 
+ifeq ($(CONFIG_IMX9_ROMAPI), y)
+  CHIP_CSRCS += imx9_romapi.c
+endif
+
+ifeq ($(CONFIG_IMX9_AHAB_BOOT), y)
+  CHIP_CSRCS += imx9_ahab.c
+endif
+
 ifeq ($(CONFIG_IMX9_DDR_TRAINING),y)
   CHIP_CSRCS += $(DDR_CSRCS)
 endif

--- a/arch/arm64/src/imx9/hardware/imx9_ele.h
+++ b/arch/arm64/src/imx9/hardware/imx9_ele.h
@@ -26,24 +26,35 @@
  ****************************************************************************/
 
 #include <hardware/imx9_memorymap.h>
+#include <stdint.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
 #define ELE_MAX_MSG               255U
-#define AHAB_VERSION              0x6
-#define AHAB_CMD_TAG              0x17
-#define AHAB_RESP_TAG             0xe1
-#define ELE_RELEASE_RDC_REQ       0xc4
-#define ELE_READ_FUSE_REQ         0x97
-#define ELE_GET_EVENTS_REQ        0xa2
+
+#define ELE_CMD_TAG               0x17
+#define ELE_VERSION               0x6
+#define ELE_VERSION_FW            0x7
+#define ELE_RESP_TAG              0xe1
+#define ELE_OK                    0xd6
+
+/* ELE commands. */
+
 #define ELE_DERIVE_KEY_REQ        0xa9
+#define ELE_GET_EVENTS_REQ        0xa2
+#define ELE_GET_TRNG_STATE_REQ    0xa4
+#define ELE_GET_RNG_REQ           0xcd
 #define ELE_FWD_LIFECYCLE_UP_REQ  0x95
 #define ELE_OEM_CNTN_AUTH_REQ     0x87
-#define ELE_VERIFY_IMAGE_REQ      0x88
+#define ELE_READ_FUSE_REQ         0x97
 #define ELE_RELEASE_CONTAINER_REQ 0x89
-#define ELE_OK                    0xd6
+#define ELE_RELEASE_RDC_REQ       0xc4
+#define ELE_START_RNG_REQ         0xa3
+#define ELE_VERIFY_IMAGE_REQ      0x88
+
+/* Messaging Unit registers. */
 
 #define ELE_MU_TCR (IMX9_S3MUA_BASE+ 0x120)
 #define ELE_MU_TSR (IMX9_S3MUA_BASE+ 0x124)
@@ -55,7 +66,13 @@
 #define ELE_MU_TR(i) (IMX9_S3MUA_BASE + 0x200 + (i) * 4)
 #define ELE_MU_RR(i) (IMX9_S3MUA_BASE + 0x280 + (i) * 4)
 
+/* Fuse and Status Block lifecycle register. */
+
 #define FSB_LC_REG              0x4751041cUL
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
 
 struct ele_header_t
 {

--- a/arch/arm64/src/imx9/hardware/imx9_ele.h
+++ b/arch/arm64/src/imx9/hardware/imx9_ele.h
@@ -31,16 +31,19 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ELE_MAX_MSG             255U
-#define AHAB_VERSION            0x6
-#define AHAB_CMD_TAG            0x17
-#define AHAB_RESP_TAG           0xe1
-#define ELE_RELEASE_RDC_REQ     0xc4
-#define ELE_READ_FUSE_REQ       0x97
-#define ELE_GET_EVENTS          0xa2
-#define ELE_DERIVE_KEY_REQ      0xa9
-#define ELE_FWD_LIFECYCLE_UP    0x95
-#define ELE_OK                  0xd6
+#define ELE_MAX_MSG               255U
+#define AHAB_VERSION              0x6
+#define AHAB_CMD_TAG              0x17
+#define AHAB_RESP_TAG             0xe1
+#define ELE_RELEASE_RDC_REQ       0xc4
+#define ELE_READ_FUSE_REQ         0x97
+#define ELE_GET_EVENTS_REQ        0xa2
+#define ELE_DERIVE_KEY_REQ        0xa9
+#define ELE_FWD_LIFECYCLE_UP_REQ  0x95
+#define ELE_OEM_CNTN_AUTH_REQ     0x87
+#define ELE_VERIFY_IMAGE_REQ      0x88
+#define ELE_RELEASE_CONTAINER_REQ 0x89
+#define ELE_OK                    0xd6
 
 #define ELE_MU_TCR (IMX9_S3MUA_BASE+ 0x120)
 #define ELE_MU_TSR (IMX9_S3MUA_BASE+ 0x124)

--- a/arch/arm64/src/imx9/imx9_ahab.c
+++ b/arch/arm64/src/imx9/imx9_ahab.c
@@ -1,0 +1,120 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx9_ahab.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+#include <debug.h>
+#include <stdio.h>
+#include <nuttx/nuttx.h>
+#include <nuttx/arch.h>
+#include "imx9_ele.h"
+#include <arch/imx9/imx9_romapi.h>
+#include <arch/imx9/imx9_ahab.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+struct boot_img_hdr *ahab_read_auth_image(struct container_hdr *container,
+                                          int image_index,
+                                          unsigned long container_offset)
+{
+  struct boot_img_hdr *images;
+  unsigned long offset;
+  unsigned long size;
+
+  _info("Image index is %d number of container images are %hhu\n",
+        image_index, container->num_images);
+  if (image_index > container->num_images)
+    {
+      _info("[%s]: Invalid image number\n", __func__);
+      return NULL;
+    }
+
+  images = (struct boot_img_hdr *)((uint8_t *)container +
+           sizeof(struct container_hdr));
+
+  uint32_t ret;
+  uint32_t pagesize;
+  ret = imx9_romapi_query_boot_infor(QUERY_PAGE_SZ, &pagesize);
+  if (ret != ROMAPI_OK)
+    {
+      _err("[%s]: Failed to query pagesize\n", __func__);
+      return NULL;
+    }
+
+  if (!IS_ALIGNED(images[image_index].offset, pagesize))
+    {
+      _err("[%s]: image%d offset not aligned to %u\n", __func__,
+           image_index, pagesize);
+      return NULL;
+    }
+
+  size = ALIGN_UP(images[image_index].size, pagesize);
+
+  offset = images[image_index].offset + container_offset;
+
+  _info("[%s]: container: %p offset: %lu size: %lu\n", __func__,
+        container, offset, size);
+
+  imx9_romapi_load_image((uint8_t *)images[image_index].dst, offset,
+                          size);
+
+  /* Flush the cache so ELE can read from RAM the updated values. */
+
+  up_flush_dcache((unsigned long)images[image_index].dst,
+                  images[image_index].dst + size);
+
+  uint32_t respo;
+  if (imx9_ele_verify_image(image_index, &respo))
+    {
+      _err("[%s]: Failed with response %x\n", __func__, respo);
+      return NULL;
+    }
+  else
+    {
+      _info("[%s]: Image successfully verified.", __func__);
+    }
+
+  return &images[image_index];
+}
+
+int ahab_auth_release(void)
+{
+  int err;
+  uint32_t resp;
+
+  err = imx9_ele_release_container(&resp);
+  if (err)
+    {
+      _err("[%s]: ELE error 0x%x\n", __func__, resp);
+    }
+  else
+    {
+      _info("[%s]: Container successfully released\n", __func__);
+    }
+
+  return err;
+}

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -142,9 +142,11 @@ void arm64_chip_boot(void)
 #endif
 #endif
 
+#ifdef CONFIG_ARCH_USE_MMU
   /* MAP IO and DRAM, enable MMU. */
 
   arm64_mmu_init(true);
+#endif
 
   /* Do UART early initialization & pin muxing */
 

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -126,7 +126,7 @@ void arm64_el_init(void)
 
 void arm64_chip_boot(void)
 {
-#ifdef CONFIG_IMX9_BOOTLOADER
+#if defined(CONFIG_IMX9_BOOTLOADER) && CONFIG_ARCH_ARM64_EXCEPTION_LEVEL == 3
   imx9_mix_powerup();
 
   /* Before DDR init we need to initialize clocks and trdc */

--- a/arch/arm64/src/imx9/imx9_ele.c
+++ b/arch/arm64/src/imx9/imx9_ele.c
@@ -22,16 +22,8 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-
-#include <stdint.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <nuttx/arch.h>
-#include <nuttx/clock.h>
 #include <debug.h>
-
-#include <arch/board/board.h>
+#include <errno.h>
 
 #include "chip.h"
 #include "arm64_internal.h"
@@ -50,11 +42,23 @@
 #define upper_32_bits(n) ((uint32_t)(((n) >> 16) >> 16))
 #define lower_32_bits(n) ((uint32_t)(n))
 
+#define ELE_RNG_TIMEOUT_US    5000
+#define ELE_RNG_SLEEP_US      100
+#define ELE_TRNG_STATUS_READY 0x3
+#define ELE_CSAL_STATUS_READY 0x2
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
 
 struct ele_msg msg;
+
+struct ele_trng_state
+{
+  uint8_t  trng_state;
+  uint8_t  csal_state;
+  uint16_t reserved;
+};
 
 /****************************************************************************
  * Private Function Prototypes
@@ -152,8 +156,8 @@ void imx9_ele_init(void)
 
 int imx9_ele_release_rdc(uint32_t rdc_id)
 {
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 2;
   msg.header.command = ELE_RELEASE_RDC_REQ;
   msg.data[0] = rdc_id;
@@ -173,8 +177,8 @@ uint32_t imx9_ele_read_common_fuse(uint32_t fuse_id)
 {
   uint32_t value = 0;
 
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 2;
   msg.header.command = ELE_READ_FUSE_REQ;
   msg.data[0] = fuse_id;
@@ -223,8 +227,8 @@ int imx9_ele_get_key(uint8_t *key, size_t key_size,
       return -EINVAL;
     }
 
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 7;
   msg.header.command = ELE_DERIVE_KEY_REQ;
   msg.data[0] = upper_32_bits((ulong)key);
@@ -262,8 +266,8 @@ int imx9_ele_get_events(uint32_t *buffer, size_t buffer_size)
   size_t events_num;
   size_t i;
 
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 1;
   msg.header.command = ELE_GET_EVENTS_REQ;
 
@@ -293,8 +297,8 @@ int imx9_ele_get_events(uint32_t *buffer, size_t buffer_size)
 
 int imx9_ele_close_device(void)
 {
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 2;
   msg.header.command = ELE_FWD_LIFECYCLE_UP_REQ;
   msg.data[0] = 0x08;
@@ -317,8 +321,8 @@ uint32_t imx9_ele_get_lifecycle(void)
 
 int imx9_ele_auth_oem_ctnr(unsigned long ctnr_addr, uint32_t *response)
 {
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 3;
   msg.header.command = ELE_OEM_CNTN_AUTH_REQ;
   msg.data[0] = upper_32_bits(ctnr_addr);
@@ -341,8 +345,8 @@ int imx9_ele_auth_oem_ctnr(unsigned long ctnr_addr, uint32_t *response)
 
 int imx9_ele_release_container(uint32_t *response)
 {
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 1;
   msg.header.command = ELE_RELEASE_CONTAINER_REQ;
 
@@ -364,8 +368,8 @@ int imx9_ele_release_container(uint32_t *response)
 
 int imx9_ele_verify_image(uint32_t img_id, uint32_t *response)
 {
-  msg.header.version = AHAB_VERSION;
-  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
   msg.header.size = 2;
   msg.header.command = ELE_VERIFY_IMAGE_REQ;
   msg.data[0] = 1 << img_id;
@@ -380,6 +384,106 @@ int imx9_ele_verify_image(uint32_t img_id, uint32_t *response)
 
   if ((msg.data[0] & 0xff) == ELE_OK)
     {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_start_rng(void)
+{
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
+  msg.header.size = 1;
+  msg.header.command = ELE_START_RNG_REQ;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_get_trng_state(void)
+{
+  msg.header.version = ELE_VERSION;
+  msg.header.tag = ELE_CMD_TAG;
+  msg.header.size = 1;
+  msg.header.command = ELE_GET_TRNG_STATE_REQ;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      struct ele_trng_state *ele_trng =
+        (struct ele_trng_state *)(msg.data + 1);
+      if (ele_trng->trng_state != ELE_TRNG_STATUS_READY ||
+          ele_trng->csal_state != ELE_CSAL_STATUS_READY)
+        {
+          /* Ensure imx9_ele_start_rng() was called earlier or we will
+           * end up here.
+           */
+
+          return -EBUSY;
+        }
+      else
+        {
+          return 0;
+        }
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_get_random(uint32_t paddr, size_t len)
+{
+  uint16_t counter = 0;
+  uint16_t max_tries = ELE_RNG_TIMEOUT_US / ELE_RNG_SLEEP_US;
+
+  if (paddr == 0 || len == 0)
+    {
+      _err("Wrong input parameters!\n");
+      return -EINVAL;
+    }
+
+  while ((imx9_ele_get_trng_state() != 0))
+    {
+      if (counter > max_tries)
+        {
+          _err("Timed out after %hu iterations!\n", counter);
+          return -EBUSY;
+        }
+
+      usleep(ELE_RNG_SLEEP_US);
+      counter++;
+    }
+
+  /* Flush the cache before sending the request to ELE. */
+
+  up_flush_dcache((uintptr_t)paddr, (uintptr_t)(paddr + len));
+
+  msg.header.version = ELE_VERSION_FW;
+  msg.header.tag = ELE_CMD_TAG;
+  msg.header.size = 4;
+  msg.header.command = ELE_GET_RNG_REQ;
+  msg.data[0] = 0;
+  msg.data[1] = paddr;
+  msg.data[2] = len;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      /* Invalidate the cache so we can read the result from RAM. */
+
+      up_invalidate_dcache((uintptr_t)paddr,
+                           (uintptr_t)(paddr + len));
       return 0;
     }
 

--- a/arch/arm64/src/imx9/imx9_ele.c
+++ b/arch/arm64/src/imx9/imx9_ele.c
@@ -265,7 +265,7 @@ int imx9_ele_get_events(uint32_t *buffer, size_t buffer_size)
   msg.header.version = AHAB_VERSION;
   msg.header.tag = AHAB_CMD_TAG;
   msg.header.size = 1;
-  msg.header.command = ELE_GET_EVENTS;
+  msg.header.command = ELE_GET_EVENTS_REQ;
 
   imx9_ele_sendmsg(&msg);
   imx9_ele_receivemsg(&msg);
@@ -296,7 +296,7 @@ int imx9_ele_close_device(void)
   msg.header.version = AHAB_VERSION;
   msg.header.tag = AHAB_CMD_TAG;
   msg.header.size = 2;
-  msg.header.command = ELE_FWD_LIFECYCLE_UP;
+  msg.header.command = ELE_FWD_LIFECYCLE_UP_REQ;
   msg.data[0] = 0x08;
 
   imx9_ele_sendmsg(&msg);
@@ -315,3 +315,73 @@ uint32_t imx9_ele_get_lifecycle(void)
   return (getreg32(FSB_LC_REG) & 0x3ff);
 }
 
+int imx9_ele_auth_oem_ctnr(unsigned long ctnr_addr, uint32_t *response)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 3;
+  msg.header.command = ELE_OEM_CNTN_AUTH_REQ;
+  msg.data[0] = upper_32_bits(ctnr_addr);
+  msg.data[1] = lower_32_bits(ctnr_addr);
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+  if (response)
+    {
+      *response = msg.data[0];
+    }
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_release_container(uint32_t *response)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 1;
+  msg.header.command = ELE_RELEASE_CONTAINER_REQ;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if (response)
+    {
+      *response = msg.data[0];
+    }
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_verify_image(uint32_t img_id, uint32_t *response)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 2;
+  msg.header.command = ELE_VERIFY_IMAGE_REQ;
+  msg.data[0] = 1 << img_id;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if (response)
+    {
+      *response = msg.data[0];
+    }
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}

--- a/arch/arm64/src/imx9/imx9_ele.h
+++ b/arch/arm64/src/imx9/imx9_ele.h
@@ -161,4 +161,60 @@ int imx9_ele_close_device(void);
 
 uint32_t imx9_ele_get_lifecycle(void);
 
+/****************************************************************************
+ * Name: imx9_ele_auth_oem_ctnr
+ *
+ * Description:
+ *   Authenticate container header.
+ *
+ * Input Parameters:
+ *   ctnr_addr - Address of the container header.
+ *
+ * Output Parameters:
+ *   response - ELE response, can be used for debugging.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_auth_oem_ctnr(unsigned long ctnr_addr, uint32_t *response);
+
+/****************************************************************************
+ * Name: imx9_ele_release_container
+ *
+ * Description:
+ *   Release the container from the ELE, used after imx9_ele_auth_oem_ctnr().
+ *
+ * Output Parameters:
+ *   response - ELE response, can be used for debugging.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_release_container(uint32_t *response);
+
+/****************************************************************************
+ * Name: imx9_ele_verify_image
+ *
+ * Description:
+ *   Verify the specified image, for the current container.
+ *
+ * Input Parameters:
+ *   img_id - The id of the image in the context of the current container.
+ *
+ * Output Parameters:
+ *   response - ELE response, can be used for debugging.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_verify_image(uint32_t img_id, uint32_t *response);
 #endif /* __ARCH_ARM64_SRC_IMX9_IMX9_ELE_H */

--- a/arch/arm64/src/imx9/imx9_ele.h
+++ b/arch/arm64/src/imx9/imx9_ele.h
@@ -25,8 +25,9 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
 #include "hardware/imx9_ele.h"
+#include <sys/types.h>
+#include <stdint.h>
 
 /****************************************************************************
  * Public Function Prototypes
@@ -217,4 +218,51 @@ int imx9_ele_release_container(uint32_t *response);
  ****************************************************************************/
 
 int imx9_ele_verify_image(uint32_t img_id, uint32_t *response);
+
+/****************************************************************************
+ * Name: imx9_ele_start_rng
+ *
+ * Description:
+ *   Sends command to initialize the ELE RNG context.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_start_rng(void);
+
+/****************************************************************************
+ * Name: imx9_ele_get_trng_state
+ *
+ * Description:
+ *   Query the state of the True Random Number Generator.
+ *
+ * Returned Value:
+ *   Zero is returned if the Random Number Generator (RNG) is ready for use.
+ *   A negated errno value (-EBUSY) or another is returned on failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_get_trng_state(void);
+
+/****************************************************************************
+ * Name: imx9_ele_get_random
+ *
+ * Description:
+ *   Request from the ELE the generation of a random number of specified
+ *   length.
+ *
+ * Input Parameters:
+ *   paddr  -  32bit physical address to store the random number.
+ *   len    -  Length in bytes of the random number.
+ *
+ * Returned Value:
+ *   Zero is returned if ELE successfully generated the random number.
+ *   A negated errno value (-EBUSY) or another is returned on failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_get_random(uint32_t paddr, size_t len);
 #endif /* __ARCH_ARM64_SRC_IMX9_IMX9_ELE_H */

--- a/arch/arm64/src/imx9/imx9_romapi.c
+++ b/arch/arm64/src/imx9/imx9_romapi.c
@@ -1,0 +1,171 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx9_romapi.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <arch/imx9/imx9_romapi.h>
+#include <nuttx/nuttx.h>
+#include <imx_container.h>
+#include <debug.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* i.MX9 ROM API structure. */
+
+struct romapi_s
+{
+  uint16_t ver;
+  uint16_t tag;
+  uint32_t reserved1;
+  uint32_t (*load_image)(uint8_t *dest, uint32_t offset, uint32_t size,
+                         uint32_t xor);
+  uint32_t (*query_boot_infor)(uint32_t infor_type, uint32_t *infor,
+                               uint32_t xor);
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Physical address of the ROM api. */
+
+static struct romapi_s *imx9_romapi_s = (struct romapi_s *)0x1980;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+uint32_t imx9_romapi_load_image(uint8_t *dest, uint32_t offset,
+                                uint32_t size)
+{
+  uint32_t xor;
+  uint32_t ret;
+
+  xor = (uintptr_t)dest ^ offset ^ size;
+  ret = imx9_romapi_s->load_image(dest, offset, size, xor);
+
+  if (ret != ROMAPI_OK)
+    {
+      _err("[%s]: Couldn't download image.", __func__);
+    }
+
+  return ret;
+}
+
+uint32_t imx9_romapi_query_boot_infor(uint32_t infor_type, uint32_t *infor)
+{
+  uint32_t ret;
+  uint32_t xor;
+
+  xor = infor_type ^ (uintptr_t)infor;
+  ret = imx9_romapi_s->query_boot_infor(infor_type, infor, xor);
+
+  if (ret != ROMAPI_OK)
+    {
+      _err("[%s]: Couldn't query boot info.", __func__);
+    }
+
+  return ret;
+}
+
+enum imx9_romapi_bootdev_e imx9_romapi_get_boot_device(void)
+{
+  int ret;
+  uint32_t boot;
+  enum imx9_romapi_bootdev_e boot_type;
+  uint32_t xor = (uintptr_t)&boot ^ QUERY_BOOT_DEV;
+
+  ret = imx9_romapi_s->query_boot_infor(QUERY_BOOT_DEV, &boot, xor);
+
+  if (ret != ROMAPI_OK)
+    {
+      return BOOTDEV_INVALID;
+    }
+
+  boot_type = boot >> 16;
+
+  switch (boot_type)
+    {
+      case BOOTDEV_SD:
+        break;
+      case BOOTDEV_MMC:
+        break;
+      case BOOTDEV_NAND:
+        break;
+      case BOOTDEV_FLEXSPI_NOR:
+        break;
+      case BOOTDEV_SPI_NOR:
+        break;
+      case BOOTDEV_FLEXSPI_NAND:
+        break;
+      case BOOTDEV_USB:
+        break;
+      case BOOTDEV_MEM_DEV:
+        break;
+      default:
+        _err("[%s]: Invalid boot device.\n", __func__);
+        boot_type = BOOTDEV_INVALID;
+        break;
+    }
+
+  return boot_type;
+}
+
+int64_t imx9_romapi_get_seq_cntr_base(uint32_t image_offset,
+                                      uint32_t pagesize,
+                                      uint8_t cntr_idx)
+{
+  uint32_t size;
+  uint32_t ret;
+  uint16_t cntr_size;
+  struct container_hdr *hdr;
+
+  size = ALIGN_UP(sizeof(struct container_hdr), pagesize);
+  hdr = (struct container_hdr *)(CONFIG_IMX_AHAB_CNTR_ADDR);
+
+  if (CONTAINER_HDR_ALIGNMENT % pagesize != 0)
+    {
+      _err("[%s]: Unsupported pagesize.\n", __func__);
+      return -1;
+    }
+
+  for (uint8_t i = 0; i < cntr_idx; i++)
+    {
+      ret = imx9_romapi_load_image((uint8_t *)CONFIG_IMX_AHAB_CNTR_ADDR,
+                                       image_offset, size);
+      if (ret != ROMAPI_OK)
+        {
+          _err("[%s]: Failure at iteration %hhu\n", __func__, i);
+          return -1;
+        }
+
+      cntr_size = hdr->length_lsb + (hdr->length_msb << 8);
+      image_offset = ALIGN_UP((cntr_size + image_offset),
+                              CONTAINER_HDR_ALIGNMENT);
+    }
+
+  return image_offset;
+}

--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -80,7 +80,11 @@ endif()
 
 if(NOT CONFIG_DEV_OPTEE_NONE)
   list(APPEND SRCS optee.c)
-  list(APPEND SRCS optee_socket.c)
+  if(CONFIG_DEV_OPTEE_SMC)
+    list(APPEND SRCS optee_smc.c)
+  else()
+    list(APPEND SRCS optee_socket.c)
+  endif()
 endif()
 
 if(CONFIG_GOLDFISH_PIPE)

--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -80,6 +80,7 @@ endif()
 
 if(NOT CONFIG_DEV_OPTEE_NONE)
   list(APPEND SRCS optee.c)
+  list(APPEND SRCS optee_socket.c)
 endif()
 
 if(CONFIG_GOLDFISH_PIPE)

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -43,20 +43,23 @@ choice
 	prompt "Select OP-TEE dev implementation"
 	default DEV_OPTEE_NONE
 	---help---
-		There are two implementations of optee server,
+		There are three implementations of optee server,
 		one is soft tee server which does not distinguish
 		between secure and non-secure states and uses socket communication,
-		and the other is teeos which runs in the secure state of
-		the cpu and uses rpmsg cross-core communication.
+		and the other two is teeos which runs in the secure state of
+		the cpu and uses either RPMsg cross-core communication or arm SMCs.
+		Warning: SMC implementation has only been tested on arm64.
 
 config DEV_OPTEE_LOCAL
 	bool "OPTEE Local Socket Support"
 	depends on NET_LOCAL
+	depends on LIBC_MEMFD_SHMFS
 	depends on ALLOW_BSD_COMPONENTS
 
 config DEV_OPTEE_RPMSG
 	bool "OP-TEE RPMSG Socket Support"
 	depends on NET_RPMSG
+	depends on LIBC_MEMFD_SHMFS
 	depends on ALLOW_BSD_COMPONENTS
 
 config DEV_OPTEE_NONE
@@ -64,10 +67,13 @@ config DEV_OPTEE_NONE
 
 endchoice
 
+if DEV_OPTEE_RPMSG
+
 config OPTEE_REMOTE_CPU_NAME
 	string "The cpuname on which the OP-TEE server runs"
 	default "tee"
-	depends on DEV_OPTEE_RPMSG
+
+endif # DEV_OPTEE_RPMSG
 
 config DRVR_MKRD
 	bool "RAM disk wrapper (mkrd)"

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -62,6 +62,12 @@ config DEV_OPTEE_RPMSG
 	depends on LIBC_MEMFD_SHMFS
 	depends on ALLOW_BSD_COMPONENTS
 
+config DEV_OPTEE_SMC
+	bool "OP-TEE SMC CC Support"
+	depends on ARCH_ARM || ARCH_ARM64
+	depends on LIBC_MEMFD_SHMFS
+	depends on ALLOW_BSD_COMPONENTS
+
 config DEV_OPTEE_NONE
 	bool "Disable OP-TEE driver"
 
@@ -74,6 +80,26 @@ config OPTEE_REMOTE_CPU_NAME
 	default "tee"
 
 endif # DEV_OPTEE_RPMSG
+
+if DEV_OPTEE_SMC
+
+choice
+	prompt "Select OP-TEE conduit method"
+	default DEV_OPTEE_SMC_CONDUIT_SMC
+	---help---
+		Select between the 2 supported conduit methods for invoking the secure
+		world: SMC (when running at EL1) and HVC (when running at EL2, which is
+		not supported by NuttX yet).
+
+config DEV_OPTEE_SMC_CONDUIT_SMC
+	bool "Use SMC calls to invoke OP-TEE"
+
+config DEV_OPTEE_SMC_CONDUIT_HVC
+	bool "Use HVC calls to invoke OP-TEE"
+
+endchoice
+
+endif # DEV_OPTEE_SMC
 
 config DRVR_MKRD
 	bool "RAM disk wrapper (mkrd)"

--- a/drivers/misc/Make.defs
+++ b/drivers/misc/Make.defs
@@ -77,6 +77,7 @@ endif
 
 ifneq ($(CONFIG_DEV_OPTEE_NONE),y)
   CSRCS += optee.c
+  CSRCS += optee_socket.c
 endif
 
 ifeq ($(CONFIG_GOLDFISH_PIPE),y)

--- a/drivers/misc/Make.defs
+++ b/drivers/misc/Make.defs
@@ -77,7 +77,11 @@ endif
 
 ifneq ($(CONFIG_DEV_OPTEE_NONE),y)
   CSRCS += optee.c
-  CSRCS += optee_socket.c
+  ifeq ($(CONFIG_DEV_OPTEE_SMC),y)
+    CSRCS += optee_smc.c
+  else
+    CSRCS += optee_socket.c
+  endif
 endif
 
 ifeq ($(CONFIG_GOLDFISH_PIPE),y)

--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -248,6 +248,17 @@ static int optee_from_msg_param(FAR struct tee_ioctl_param *params,
   return 0;
 }
 
+static int optee_close_session(FAR struct optee_priv_data *priv,
+                               uint32_t session)
+{
+  struct optee_msg_arg msg;
+
+  memset(&msg, 0, sizeof(struct optee_msg_arg));
+  msg.cmd = OPTEE_MSG_CMD_CLOSE_SESSION;
+  msg.session = session;
+  return optee_transport_call(priv, &msg);
+}
+
 static int optee_ioctl_open_session(FAR struct optee_priv_data *priv,
                                     FAR struct tee_ioctl_buf_data *buf)
 {
@@ -318,6 +329,7 @@ static int optee_ioctl_open_session(FAR struct optee_priv_data *priv,
                              msg->params + 2);
   if (ret < 0)
     {
+      optee_close_session(priv, msg->session);
       return ret;
     }
 
@@ -393,13 +405,7 @@ static int
 optee_ioctl_close_session(FAR struct optee_priv_data *priv,
                           FAR struct tee_ioctl_close_session_arg *arg)
 {
-  struct optee_msg_arg msg;
-
-  memset(&msg, 0, sizeof(struct optee_msg_arg));
-  msg.cmd = OPTEE_MSG_CMD_CLOSE_SESSION;
-  msg.session = arg->session;
-  msg.num_params = 0;
-  return optee_transport_call(priv, &msg);
+  return optee_close_session(priv, arg->session);
 }
 
 static int optee_ioctl_version(FAR struct tee_ioctl_version_data *vers)

--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -663,7 +663,7 @@ static int optee_ioctl_open_session(FAR struct optee_priv_data *priv,
 
   if (!optee_is_valid_range(buf, sizeof(*buf)))
     {
-      return -EINVAL;
+      return -EFAULT;
     }
 
   if (buf->buf_len > TEE_MAX_ARG_SIZE ||
@@ -676,7 +676,7 @@ static int optee_ioctl_open_session(FAR struct optee_priv_data *priv,
 
   if (!optee_is_valid_range(arg, buf->buf_len))
     {
-      return -EINVAL;
+      return -EFAULT;
     }
 
   if (sizeof(*arg) + TEE_IOCTL_PARAM_SIZE(arg->num_params) !=
@@ -757,7 +757,7 @@ static int optee_ioctl_invoke(FAR struct optee_priv_data *priv,
 
   if (!optee_is_valid_range(buf, sizeof(*buf)))
     {
-      return -EINVAL;
+      return -EFAULT;
     }
 
   if (buf->buf_len > TEE_MAX_ARG_SIZE ||
@@ -770,7 +770,7 @@ static int optee_ioctl_invoke(FAR struct optee_priv_data *priv,
 
   if (!optee_is_valid_range(arg, buf->buf_len))
     {
-      return -EINVAL;
+      return -EFAULT;
     }
 
   if (sizeof(*arg) + TEE_IOCTL_PARAM_SIZE(arg->num_params) !=
@@ -830,7 +830,7 @@ optee_ioctl_close_session(FAR struct optee_priv_data *priv,
 {
   if (!optee_is_valid_range(arg, sizeof(*arg)))
     {
-      return -EINVAL;
+      return -EFAULT;
     }
 
   return optee_close_session(priv, arg->session);
@@ -854,7 +854,7 @@ static int optee_ioctl_cancel(FAR struct optee_priv_data *priv,
 
   if (!optee_is_valid_range(arg, sizeof(*arg)))
     {
-      return -EINVAL;
+      return -EFAULT;
     }
 
   optee_msg_alloc(priv, 0, msg);
@@ -879,7 +879,7 @@ optee_ioctl_shm_alloc(FAR struct tee_ioctl_shm_alloc_data *data)
 
   if (!optee_is_valid_range(data, sizeof(*data)))
     {
-      return -EINVAL;
+      return -EFAULT;
     }
 
   memfd = memfd_create(OPTEE_SERVER_PATH, O_CREAT | O_CLOEXEC);
@@ -916,13 +916,13 @@ optee_ioctl_shm_register(FAR struct optee_priv_data *priv,
 
   if (!optee_is_valid_range(rdata, sizeof(*rdata)))
     {
-      return -EACCES;
+      return -EFAULT;
     }
 
   if (!optee_is_valid_range((FAR void *)(uintptr_t)
                             rdata->addr, rdata->length))
     {
-      return -EACCES;
+      return -EFAULT;
     }
 
   if (rdata->flags & TEE_SHM_ALLOC)

--- a/drivers/misc/optee.h
+++ b/drivers/misc/optee.h
@@ -54,6 +54,7 @@ struct optee_priv_data
 struct optee_shm
 {
   FAR struct optee_priv_data *priv;
+  int fd;
   int32_t id;
   uint64_t addr;
   uint64_t length;

--- a/drivers/misc/optee.h
+++ b/drivers/misc/optee.h
@@ -51,7 +51,7 @@ struct optee_priv_data
   FAR struct idr_s *shms;     /* An RB tree of all shm entries */
 };
 
-struct optee_shm_entry
+struct optee_shm
 {
   FAR struct optee_priv_data *priv;
   int32_t id;
@@ -80,8 +80,8 @@ uintptr_t optee_va_to_pa(FAR const void *va);
 #endif
 int optee_shm_alloc(FAR struct optee_priv_data *priv, FAR void *addr,
                     size_t size, uint32_t flags,
-                    FAR struct optee_shm_entry **shmep);
-void optee_shm_free(FAR struct optee_shm_entry *shme);
+                    FAR struct optee_shm **shmp);
+void optee_shm_free(FAR struct optee_shm *shm);
 int optee_transport_init(void);
 int optee_transport_open(FAR struct optee_priv_data **priv);
 void optee_transport_close(FAR struct optee_priv_data *priv);

--- a/drivers/misc/optee.h
+++ b/drivers/misc/optee.h
@@ -58,6 +58,7 @@ struct optee_shm
   int32_t id;
   uint64_t addr;
   uint64_t length;
+  FAR void *page_list;
   uint32_t flags;
 };
 

--- a/drivers/misc/optee.h
+++ b/drivers/misc/optee.h
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * drivers/misc/optee.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __DRIVERS_MISC_OPTEE_H
+#define __DRIVERS_MISC_OPTEE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <nuttx/tee.h>
+
+#include "optee_msg.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define OPTEE_SERVER_PATH              "optee"
+#define OPTEE_MAX_PARAM_NUM            6
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct optee_priv_data
+{
+};
+
+/****************************************************************************
+ * Public Functions Definitions
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+int optee_transport_init(void);
+int optee_transport_open(FAR struct optee_priv_data **priv);
+void optee_transport_close(FAR struct optee_priv_data *priv);
+int optee_transport_call(FAR struct optee_priv_data *priv,
+                         FAR struct optee_msg_arg *arg);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+#endif /* __DRIVERS_MISC_OPTEE_H */

--- a/drivers/misc/optee.h
+++ b/drivers/misc/optee.h
@@ -30,8 +30,7 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 #include <nuttx/tee.h>
-#include <nuttx/list.h>
-#include <nuttx/spinlock.h>
+#include <nuttx/idr.h>
 
 #include "optee_msg.h"
 
@@ -46,17 +45,19 @@
  * Public Types
  ****************************************************************************/
 
-struct optee_shm_entry
-{
-  struct list_node node;
-  struct tee_ioctl_shm_register_data shm;
-};
-
 struct optee_priv_data
 {
   uintptr_t alignment;        /* Transport-specified message alignment */
-  struct list_node shm_list;  /* A list of all shm registered */
-  spinlock_t lock;            /* Lock used to guard list accesses */
+  FAR struct idr_s *shms;     /* An RB tree of all shm entries */
+};
+
+struct optee_shm_entry
+{
+  FAR struct optee_priv_data *priv;
+  int32_t id;
+  uint64_t addr;
+  uint64_t length;
+  uint32_t flags;
 };
 
 /****************************************************************************
@@ -80,8 +81,7 @@ uintptr_t optee_va_to_pa(FAR const void *va);
 int optee_shm_alloc(FAR struct optee_priv_data *priv, FAR void *addr,
                     size_t size, uint32_t flags,
                     FAR struct optee_shm_entry **shmep);
-void optee_shm_free(FAR struct optee_priv_data *priv,
-                    FAR struct optee_shm_entry *shme);
+void optee_shm_free(FAR struct optee_shm_entry *shme);
 int optee_transport_init(void);
 int optee_transport_open(FAR struct optee_priv_data **priv);
 void optee_transport_close(FAR struct optee_priv_data *priv);

--- a/drivers/misc/optee_smc.c
+++ b/drivers/misc/optee_smc.c
@@ -1,0 +1,343 @@
+/****************************************************************************
+ * drivers/misc/optee_smc.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/kmalloc.h>
+#include <errno.h>
+#include <syslog.h>
+#include <string.h>
+
+#include "optee.h"
+#include "optee_smc.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ARM)
+#  define smccc_smc                  arm_smccc_smc
+#  define smccc_hvc                  arm_smccc_hvc
+#  define smccc_res_t                arm_smccc_res_t
+#elif defined(CONFIG_ARCH_ARM64)
+#  define smccc_smc                  arm64_smccc_smc
+#  define smccc_hvc                  arm64_smccc_hvc
+#  define smccc_res_t                arm64_smccc_res_t
+#else
+#  error "CONFIG_DEV_OPTEE_SMC is only supported on arm and arm64"
+#endif
+
+#ifdef CONFIG_DEV_OPTEE_SMC_CONDUIT_SMC
+#  define smc_conduit                smccc_smc
+#else
+#  define smc_conduit                smccc_hvc
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+typedef void (*optee_smc_fn)(unsigned long, unsigned long, unsigned long,
+                             unsigned long, unsigned long, unsigned long,
+                             unsigned long, unsigned long,
+                             FAR smccc_res_t *);
+
+struct optee_smc_priv_data
+{
+  struct optee_priv_data base;
+  optee_smc_fn smc_fn;
+};
+
+union optee_smc_os_revision
+{
+  smccc_res_t smccc;
+  struct optee_smc_call_get_os_revision_result result;
+};
+
+union optee_smc_calls_revision
+{
+  smccc_res_t smccc;
+  struct optee_smc_calls_revision_result result;
+};
+
+union optee_smc_exchg_caps
+{
+  smccc_res_t smccc;
+  struct optee_smc_exchange_capabilities_result result;
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static inline uintptr_t reg_pair_to_uintptr(uint64_t reg0, uint64_t reg1)
+{
+  return (uintptr_t)(reg0 << 32 | (reg1 & UINT32_MAX));
+}
+
+static inline void reg_pair_from_64(uint64_t val, uint64_t *reg0,
+                                    uint64_t *reg1)
+{
+  *reg0 = val >> 32;
+  *reg1 = val & UINT32_MAX;
+}
+
+static bool optee_smc_is_compatible(optee_smc_fn smc_fn)
+{
+  union optee_smc_os_revision osrev;
+  union optee_smc_calls_revision callsrev;
+  union optee_smc_exchg_caps xchgcaps;
+  smccc_res_t callsuid;
+
+  /* Print the OS revision and build ID (if reported) */
+
+  osrev.result.build_id = 0;
+
+  smc_fn(OPTEE_SMC_CALL_GET_OS_REVISION, 0, 0, 0, 0, 0, 0, 0, &osrev.smccc);
+
+  if (osrev.result.build_id)
+    {
+      syslog(LOG_INFO, "OP-TEE: OS revision %lu.%lu (%08lx)\n",
+                       osrev.result.major, osrev.result.minor,
+                       osrev.result.build_id);
+    }
+  else
+    {
+      syslog(LOG_INFO, "OP-TEE: OS revision %lu.%lu\n",
+                       osrev.result.major, osrev.result.minor);
+    }
+
+  /* Check the API UID */
+
+  smc_fn(OPTEE_SMC_CALLS_UID, 0, 0, 0, 0, 0, 0, 0, &callsuid);
+
+  if (callsuid.a0 != OPTEE_MSG_UID_0 || callsuid.a1 != OPTEE_MSG_UID_1 ||
+      callsuid.a2 != OPTEE_MSG_UID_2 || callsuid.a3 != OPTEE_MSG_UID_3)
+    {
+      syslog(LOG_ERR, "OP-TEE: API UID mismatch\n");
+      return false;
+    }
+
+  /* Check the API revision */
+
+  smc_fn(OPTEE_SMC_CALLS_REVISION, 0, 0, 0, 0, 0, 0, 0, &callsrev.smccc);
+
+  if (callsrev.result.major != OPTEE_MSG_REVISION_MAJOR ||
+      callsrev.result.minor < OPTEE_MSG_REVISION_MINOR)
+    {
+      syslog(LOG_ERR, "OP-TEE: API revision incompatible\n");
+      return false;
+    }
+
+  /* Check the capabilities */
+
+  smc_fn(OPTEE_SMC_EXCHANGE_CAPABILITIES, OPTEE_SMC_NSEC_CAP_UNIPROCESSOR,
+         0, 0, 0, 0, 0, 0, &xchgcaps.smccc);
+
+  if (xchgcaps.result.status != OPTEE_SMC_RETURN_OK)
+    {
+      syslog(LOG_ERR, "OP-TEE: Failed to exchange capabilities\n");
+      return false;
+    }
+
+  if (!(xchgcaps.result.capabilities & OPTEE_SMC_SEC_CAP_DYNAMIC_SHM))
+    {
+      syslog(LOG_ERR, "OP-TEE: Does not support dynamic shared mem\n");
+      return false;
+    }
+
+  return true;
+}
+
+static void optee_smc_handle_rpc(FAR struct optee_priv_data *priv_,
+                                 FAR smccc_res_t *par)
+{
+  FAR struct optee_shm_entry *shme;
+  uintptr_t shme_pa;
+  uint32_t rpc_func;
+
+  rpc_func = OPTEE_SMC_RETURN_GET_RPC_FUNC(par->a0);
+  par->a0 = OPTEE_SMC_CALL_RETURN_FROM_RPC;
+
+  switch (rpc_func)
+    {
+      case OPTEE_SMC_RPC_FUNC_ALLOC:
+        if (!optee_shm_alloc(priv_, NULL, par->a1,
+                             TEE_SHM_ALLOC | TEE_SHM_REGISTER, &shme))
+          {
+            shme_pa = optee_va_to_pa((FAR void *)(uintptr_t)shme->shm.addr);
+            reg_pair_from_64(shme_pa, &par->a1, &par->a2);
+            reg_pair_from_64((uintptr_t)shme, &par->a4, &par->a5);
+          }
+        else
+          {
+            reg_pair_from_64(0, &par->a1, &par->a2);
+            reg_pair_from_64(0, &par->a4, &par->a5);
+          }
+        break;
+
+      case OPTEE_SMC_RPC_FUNC_FREE:
+        shme = (FAR struct optee_shm_entry *)
+                  reg_pair_to_uintptr(par->a1, par->a2);
+        optee_shm_free(priv_, shme);
+        break;
+
+      case OPTEE_SMC_RPC_FUNC_FOREIGN_INTR:
+        break;
+
+      default:
+        syslog(LOG_ERR, "OP-TEE: RPC 0x%04x not implemented\n", rpc_func);
+        break;
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: optee_transport_init
+ *
+ * Description:
+ *   Perform any initialization actions specific to the transport used
+ *   right before the driver is registered.
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int optee_transport_init(void)
+{
+  if (!optee_smc_is_compatible(smc_conduit))
+    {
+      return -ENOENT;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: optee_transport_open
+ *
+ * Description:
+ *   Perform any transport-specific actions upon driver character device
+ *   open.
+ *
+ * Parameters:
+ *   priv_  - the optee_priv_data struct to allocate and return by
+ *            reference.
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int optee_transport_open(FAR struct optee_priv_data **priv_)
+{
+  FAR struct optee_smc_priv_data *priv;
+
+  priv = kmm_zalloc(sizeof(struct optee_smc_priv_data));
+  if (priv == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  priv->base.alignment = OPTEE_MSG_NONCONTIG_PAGE_SIZE;
+  priv->smc_fn = smc_conduit;
+  *priv_ = (FAR struct optee_priv_data *)priv;
+  return 0;
+}
+
+/****************************************************************************
+ * Name: optee_transport_close
+ *
+ * Description:
+ *   Perform any transport-specific actions upon driver character device
+ *   close.
+ *
+ * Parameters:
+ *   priv_  - the optee_priv_data struct to close and de-allocate.
+ *
+ * Returned Values:
+ *  None
+ *
+ ****************************************************************************/
+
+void optee_transport_close(FAR struct optee_priv_data *priv_)
+{
+  kmm_free(priv_);
+}
+
+/****************************************************************************
+ * Name: optee_transport_call
+ *
+ * Description:
+ *   Call OP-TEE OS using SMCs.
+ *
+ * Parameters:
+ *   priv_  - the optee_priv_data struct to use
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int optee_transport_call(FAR struct optee_priv_data *priv_,
+                         FAR struct optee_msg_arg *arg)
+{
+  FAR struct optee_smc_priv_data *priv =
+                  (FAR struct optee_smc_priv_data *)priv_;
+  smccc_res_t res;
+  smccc_res_t par;
+  uintptr_t arg_pa;
+
+  memset(&par, 0, sizeof(smccc_res_t));
+
+  par.a0 = OPTEE_SMC_CALL_WITH_ARG;
+  arg_pa = optee_va_to_pa(arg);
+  reg_pair_from_64(arg_pa, &par.a1, &par.a2);
+
+  for (; ; )
+    {
+      memset(&res, 0, sizeof(smccc_res_t));
+
+      priv->smc_fn(par.a0, par.a1, par.a2, par.a3,
+                   par.a4, par.a5, par.a6, par.a7, &res);
+
+      if (OPTEE_SMC_RETURN_IS_RPC(res.a0))
+        {
+          memcpy(&par, &res, 4 * sizeof(unsigned long));
+          optee_smc_handle_rpc(priv_, &par);
+        }
+      else
+        {
+          return (int)res.a0;
+        }
+    }
+}

--- a/drivers/misc/optee_smc.c
+++ b/drivers/misc/optee_smc.c
@@ -187,10 +187,9 @@ static void optee_smc_handle_rpc(FAR struct optee_priv_data *priv_,
   switch (rpc_func)
     {
       case OPTEE_SMC_RPC_FUNC_ALLOC:
-        if (!optee_shm_alloc(priv_, NULL, par->a1,
-                             TEE_SHM_ALLOC | TEE_SHM_REGISTER, &shme))
+        if (!optee_shm_alloc(priv_, NULL, par->a1, TEE_SHM_ALLOC, &shme))
           {
-            shme_pa = optee_va_to_pa((FAR void *)(uintptr_t)shme->shm.addr);
+            shme_pa = optee_va_to_pa((FAR void *)(uintptr_t)shme->addr);
             reg_pair_from_64(shme_pa, &par->a1, &par->a2);
             reg_pair_from_64((uintptr_t)shme, &par->a4, &par->a5);
           }
@@ -204,7 +203,7 @@ static void optee_smc_handle_rpc(FAR struct optee_priv_data *priv_,
       case OPTEE_SMC_RPC_FUNC_FREE:
         shme = (FAR struct optee_shm_entry *)
                   reg_pair_to_uintptr(par->a1, par->a2);
-        optee_shm_free(priv_, shme);
+        optee_shm_free(shme);
         break;
 
       case OPTEE_SMC_RPC_FUNC_FOREIGN_INTR:

--- a/drivers/misc/optee_smc.h
+++ b/drivers/misc/optee_smc.h
@@ -1,0 +1,448 @@
+/****************************************************************************
+ * drivers/misc/optee_smc.h
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ * Copyright (c) 2015-2018, Linaro Limited
+ *
+ ****************************************************************************/
+
+#ifndef __DRIVERS_MISC_OPTEE_SMC_H
+#define __DRIVERS_MISC_OPTEE_SMC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <arch/syscall.h>
+#include <nuttx/bits.h>
+
+/* This file is based on
+ * https://github.com
+ *    /OP-TEE/optee_os/blob/master/core/arch/arm/include/sm/optee_smc.h
+ * and may need to be updated when introducing new features.
+ */
+
+#define OPTEE_SMC_STD_CALL_VAL(func_num) \
+  ARM_SMCCC_CALL_VAL(ARM_SMCCC_STD_CALL, ARM_SMCCC_SMC_32, \
+         ARM_SMCCC_OWNER_TRUSTED_OS, (func_num))
+#define OPTEE_SMC_FAST_CALL_VAL(func_num) \
+  ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL, ARM_SMCCC_SMC_32, \
+         ARM_SMCCC_OWNER_TRUSTED_OS, (func_num))
+
+/* Function specified by SMC Calling convention.
+ */
+#define OPTEE_SMC_FUNCID_CALLS_COUNT  0xFF00
+#define OPTEE_SMC_CALLS_COUNT \
+  ARM_SMCCC_CALL_VAL(OPTEE_SMC_FAST_CALL, SMCCC_SMC_32, \
+         SMCCC_OWNER_TRUSTED_OS_END, \
+         OPTEE_SMC_FUNCID_CALLS_COUNT)
+
+/* Normal cached memory (write-back), shareable for SMP systems and not
+ * shareable for UP systems.
+ */
+#define OPTEE_SMC_SHM_CACHED    1
+
+/* a0..a7 is used as register names in the descriptions below, on arm32
+ * that translates to r0..r7 and on arm64 to w0..w7. In both cases it's
+ * 32-bit registers.
+ */
+
+/* Function specified by SMC Calling convention
+ *
+ * Return one of the following UIDs if using API specified in this file
+ * without further extensions:
+ * 65cb6b93-af0c-4617-8ed6-644a8d1140f8
+ * see also OPTEE_SMC_UID_* in optee_msg.h
+ */
+#define OPTEE_SMC_FUNCID_CALLS_UID OPTEE_MSG_FUNCID_CALLS_UID
+#define OPTEE_SMC_CALLS_UID \
+  ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL, ARM_SMCCC_SMC_32, \
+         ARM_SMCCC_OWNER_TRUSTED_OS_END, \
+         OPTEE_SMC_FUNCID_CALLS_UID)
+
+/* Function specified by SMC Calling convention
+ *
+ * Returns 2.0 if using API specified in this file without further
+ * extensions. See also OPTEE_MSG_REVISION_* in optee_msg.h
+ */
+#define OPTEE_SMC_FUNCID_CALLS_REVISION OPTEE_MSG_FUNCID_CALLS_REVISION
+#define OPTEE_SMC_CALLS_REVISION \
+  ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL, ARM_SMCCC_SMC_32, \
+         ARM_SMCCC_OWNER_TRUSTED_OS_END, \
+         OPTEE_SMC_FUNCID_CALLS_REVISION)
+
+struct optee_smc_calls_revision_result
+{
+  unsigned long major;
+  unsigned long minor;
+  unsigned long reserved0;
+  unsigned long reserved1;
+};
+
+/* Get UUID of Trusted OS.
+ *
+ * Used by non-secure world to figure out which Trusted OS is installed.
+ * Note that returned UUID is the UUID of the Trusted OS, not of the API.
+ *
+ * Returns UUID in a0-4 in the same way as OPTEE_SMC_CALLS_UID
+ * described above.
+ */
+#define OPTEE_SMC_FUNCID_GET_OS_UUID OPTEE_MSG_FUNCID_GET_OS_UUID
+#define OPTEE_SMC_CALL_GET_OS_UUID \
+  OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_OS_UUID)
+
+/* Get revision of Trusted OS.
+ *
+ * Used by non-secure world to figure out which version of the Trusted OS
+ * is installed. Note that the returned revision is the revision of the
+ * Trusted OS, not of the API.
+ *
+ * Returns revision in a0-1 in the same way as OPTEE_SMC_CALLS_REVISION
+ * described above. May optionally return a 32-bit build identifier in a2,
+ * with zero meaning unspecified.
+ */
+#define OPTEE_SMC_FUNCID_GET_OS_REVISION OPTEE_MSG_FUNCID_GET_OS_REVISION
+#define OPTEE_SMC_CALL_GET_OS_REVISION \
+  OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_OS_REVISION)
+
+struct optee_smc_call_get_os_revision_result
+{
+  unsigned long major;
+  unsigned long minor;
+  unsigned long build_id;
+  unsigned long reserved1;
+};
+
+/* Call with struct optee_msg_arg as argument
+ *
+ * Call register usage:
+ * a0  SMC Function ID, OPTEE_SMC*CALL_WITH_ARG
+ * a1  Upper 32bit of a 64bit physical pointer to a struct optee_msg_arg
+ * a2  Lower 32bit of a 64bit physical pointer to a struct optee_msg_arg
+ * a3  Cache settings, not used if physical pointer is in a predefined shared
+ *  memory area else per OPTEE_SMC_SHM_*
+ * a4-6  Not used
+ * a7  Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0  Return value, OPTEE_SMC_RETURN_*
+ * a1-3  Not used
+ * a4-7  Preserved
+ *
+ * OPTEE_SMC_RETURN_ETHREAD_LIMIT return register usage:
+ * a0  Return value, OPTEE_SMC_RETURN_ETHREAD_LIMIT
+ * a1-3  Preserved
+ * a4-7  Preserved
+ *
+ * RPC return register usage:
+ * a0  Return value, OPTEE_SMC_RETURN_IS_RPC(val)
+ * a1-2  RPC parameters
+ * a3-7  Resume information, must be preserved
+ *
+ * Possible return values:
+ * OPTEE_SMC_RETURN_UNKNOWN_FUNCTION  Trusted OS does not recognize this
+ *          function.
+ * OPTEE_SMC_RETURN_OK      Call completed, result updated in
+ *          the previously supplied struct
+ *          optee_msg_arg.
+ * OPTEE_SMC_RETURN_ETHREAD_LIMIT  Number of Trusted OS threads exceeded,
+ *          try again later.
+ * OPTEE_SMC_RETURN_EBADADDR    Bad physical pointer to struct
+ *          optee_msg_arg.
+ * OPTEE_SMC_RETURN_EBADCMD    Bad/unknown cmd in struct optee_msg_arg
+ * OPTEE_SMC_RETURN_IS_RPC()    Call suspended by RPC call to normal
+ *          world.
+ */
+#define OPTEE_SMC_FUNCID_CALL_WITH_ARG OPTEE_MSG_FUNCID_CALL_WITH_ARG
+#define OPTEE_SMC_CALL_WITH_ARG \
+  OPTEE_SMC_STD_CALL_VAL(OPTEE_SMC_FUNCID_CALL_WITH_ARG)
+
+/* Get Shared Memory Config
+ *
+ * Returns the Secure/Non-secure shared memory config.
+ *
+ * Call register usage:
+ * a0  SMC Function ID, OPTEE_SMC_GET_SHM_CONFIG
+ * a1-6  Not used
+ * a7  Hypervisor Client ID register
+ *
+ * Have config return register usage:
+ * a0  OPTEE_SMC_RETURN_OK
+ * a1  Physical address of start of SHM
+ * a2  Size of of SHM
+ * a3  Cache settings of memory, as defined by the
+ *  OPTEE_SMC_SHM_* values above
+ * a4-7  Preserved
+ *
+ * Not available register usage:
+ * a0  OPTEE_SMC_RETURN_ENOTAVAIL
+ * a1-3 Not used
+ * a4-7  Preserved
+ */
+#define OPTEE_SMC_FUNCID_GET_SHM_CONFIG  7
+#define OPTEE_SMC_GET_SHM_CONFIG \
+  OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_SHM_CONFIG)
+
+struct optee_smc_get_shm_config_result
+{
+  unsigned long status;
+  unsigned long start;
+  unsigned long size;
+  unsigned long settings;
+};
+
+/* Exchanges capabilities between normal world and secure world
+ *
+ * Call register usage:
+ * a0  SMC Function ID, OPTEE_SMC_EXCHANGE_CAPABILITIES
+ * a1  bitfield of normal world capabilities OPTEE_SMC_NSEC_CAP_*
+ * a2-6  Not used
+ * a7  Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0  OPTEE_SMC_RETURN_OK
+ * a1  bitfield of secure world capabilities OPTEE_SMC_SEC_CAP_*
+ * a2-7  Preserved
+ *
+ * Error return register usage:
+ * a0  OPTEE_SMC_RETURN_ENOTAVAIL, can't use the capabilities from normal
+ *     world
+ * a1  bitfield of secure world capabilities OPTEE_SMC_SEC_CAP_*
+ * a2-7 Preserved
+ */
+
+/* Normal world works as a uniprocessor system */
+#define OPTEE_SMC_NSEC_CAP_UNIPROCESSOR      BIT(0)
+/* Secure world has reserved shared memory for normal world to use */
+#define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM  BIT(0)
+/* Secure world can communicate via previously unregistered shared memory */
+#define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM   BIT(1)
+
+/* Secure world supports commands "register/unregister shared memory",
+ * secure world accepts command buffers located in any parts of non-secure
+ * RAM
+ */
+#define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM        BIT(2)
+
+#define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES 9
+#define OPTEE_SMC_EXCHANGE_CAPABILITIES \
+  OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES)
+
+struct optee_smc_exchange_capabilities_result
+{
+  unsigned long status;
+  unsigned long capabilities;
+  unsigned long reserved0;
+  unsigned long reserved1;
+};
+
+/* Disable and empties cache of shared memory objects
+ *
+ * Secure world can cache frequently used shared memory objects, for
+ * example objects used as RPC arguments. When secure world is idle this
+ * function returns one shared memory reference to free. To disable the
+ * cache and free all cached objects this function has to be called until
+ * it returns OPTEE_SMC_RETURN_ENOTAVAIL.
+ *
+ * Call register usage:
+ * a0  SMC Function ID, OPTEE_SMC_DISABLE_SHM_CACHE
+ * a1-6  Not used
+ * a7  Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0  OPTEE_SMC_RETURN_OK
+ * a1  Upper 32bit of a 64bit Shared memory cookie
+ * a2  Lower 32bit of a 64bit Shared memory cookie
+ * a3-7  Preserved
+ *
+ * Cache empty return register usage:
+ * a0  OPTEE_SMC_RETURN_ENOTAVAIL
+ * a1-7  Preserved
+ *
+ * Not idle return register usage:
+ * a0  OPTEE_SMC_RETURN_EBUSY
+ * a1-7  Preserved
+ */
+#define OPTEE_SMC_FUNCID_DISABLE_SHM_CACHE 10
+#define OPTEE_SMC_DISABLE_SHM_CACHE \
+  OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_DISABLE_SHM_CACHE)
+
+struct optee_smc_disable_shm_cache_result
+{
+  unsigned long status;
+  unsigned long shm_upper32;
+  unsigned long shm_lower32;
+  unsigned long reserved0;
+};
+
+/* Enable cache of shared memory objects
+ *
+ * Secure world can cache frequently used shared memory objects, for
+ * example objects used as RPC arguments. When secure world is idle this
+ * function returns OPTEE_SMC_RETURN_OK and the cache is enabled. If
+ * secure world isn't idle OPTEE_SMC_RETURN_EBUSY is returned.
+ *
+ * Call register usage:
+ * a0  SMC Function ID, OPTEE_SMC_ENABLE_SHM_CACHE
+ * a1-6  Not used
+ * a7  Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0  OPTEE_SMC_RETURN_OK
+ * a1-7  Preserved
+ *
+ * Not idle return register usage:
+ * a0  OPTEE_SMC_RETURN_EBUSY
+ * a1-7  Preserved
+ */
+#define OPTEE_SMC_FUNCID_ENABLE_SHM_CACHE 11
+#define OPTEE_SMC_ENABLE_SHM_CACHE \
+  OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_ENABLE_SHM_CACHE)
+
+/* Resume from RPC (for example after processing a foreign interrupt)
+ *
+ * Call register usage:
+ * a0  SMC Function ID, OPTEE_SMC_CALL_RETURN_FROM_RPC
+ * a1-3  Value of a1-3 when OPTEE_SMC_CALL_WITH_ARG returned
+ *  OPTEE_SMC_RETURN_RPC in a0
+ *
+ * Return register usage is the same as for OPTEE_SMC_*CALL_WITH_ARG above.
+ *
+ * Possible return values
+ * OPTEE_SMC_RETURN_UNKNOWN_FUNCTION  Trusted OS does not recognize this
+ *          function.
+ * OPTEE_SMC_RETURN_OK      Original call completed, result
+ *          updated in the previously supplied.
+ *          struct optee_msg_arg
+ * OPTEE_SMC_RETURN_RPC      Call suspended by RPC call to normal
+ *          world.
+ * OPTEE_SMC_RETURN_ERESUME    Resume failed, the opaque resume
+ *          information was corrupt.
+ */
+#define OPTEE_SMC_FUNCID_RETURN_FROM_RPC  3
+#define OPTEE_SMC_CALL_RETURN_FROM_RPC \
+  OPTEE_SMC_STD_CALL_VAL(OPTEE_SMC_FUNCID_RETURN_FROM_RPC)
+
+#define OPTEE_SMC_RETURN_RPC_PREFIX_MASK  0xFFFF0000
+#define OPTEE_SMC_RETURN_RPC_PREFIX       0xFFFF0000
+#define OPTEE_SMC_RETURN_RPC_FUNC_MASK    0x0000FFFF
+
+#define OPTEE_SMC_RETURN_GET_RPC_FUNC(ret) \
+  ((ret) & OPTEE_SMC_RETURN_RPC_FUNC_MASK)
+
+#define OPTEE_SMC_RPC_VAL(func)    ((func) | OPTEE_SMC_RETURN_RPC_PREFIX)
+
+/* Allocate memory for RPC parameter passing. The memory is used to hold a
+ * struct optee_msg_arg.
+ *
+ * "Call" register usage:
+ * a0  This value, OPTEE_SMC_RETURN_RPC_ALLOC
+ * a1  Size in bytes of required argument memory
+ * a2  Not used
+ * a3  Resume information, must be preserved
+ * a4-5  Not used
+ * a6-7  Resume information, must be preserved
+ *
+ * "Return" register usage:
+ * a0  SMC Function ID, OPTEE_SMC_CALL_RETURN_FROM_RPC.
+ * a1  Upper 32bits of 64bit physical pointer to allocated
+ *  memory, (a1 == 0 && a2 == 0) if size was 0 or if memory can't
+ *  be allocated.
+ * a2  Lower 32bits of 64bit physical pointer to allocated
+ *  memory, (a1 == 0 && a2 == 0) if size was 0 or if memory can't
+ *  be allocated
+ * a3  Preserved
+ * a4  Upper 32bits of 64bit Shared memory cookie used when freeing
+ *  the memory or doing an RPC
+ * a5  Lower 32bits of 64bit Shared memory cookie used when freeing
+ *  the memory or doing an RPC
+ * a6-7  Preserved
+ */
+#define OPTEE_SMC_RPC_FUNC_ALLOC          0
+#define OPTEE_SMC_RETURN_RPC_ALLOC \
+  OPTEE_SMC_RPC_VAL(OPTEE_SMC_RPC_FUNC_ALLOC)
+
+/* Free memory previously allocated by OPTEE_SMC_RETURN_RPC_ALLOC
+ *
+ * "Call" register usage:
+ * a0  This value, OPTEE_SMC_RETURN_RPC_FREE
+ * a1  Upper 32bits of 64bit shared memory cookie belonging to this
+ *  argument memory
+ * a2  Lower 32bits of 64bit shared memory cookie belonging to this
+ *  argument memory
+ * a3-7  Resume information, must be preserved
+ *
+ * "Return" register usage:
+ * a0  SMC Function ID, OPTEE_SMC_CALL_RETURN_FROM_RPC.
+ * a1-2  Not used
+ * a3-7  Preserved
+ */
+#define OPTEE_SMC_RPC_FUNC_FREE           2
+#define OPTEE_SMC_RETURN_RPC_FREE \
+  OPTEE_SMC_RPC_VAL(OPTEE_SMC_RPC_FUNC_FREE)
+
+/* Deliver foreign interrupt to normal world.
+ *
+ * "Call" register usage:
+ * a0  OPTEE_SMC_RETURN_RPC_FOREIGN_INTR
+ * a1-7  Resume information, must be preserved
+ *
+ * "Return" register usage:
+ * a0  SMC Function ID, OPTEE_SMC_CALL_RETURN_FROM_RPC.
+ * a1-7  Preserved
+ */
+#define OPTEE_SMC_RPC_FUNC_FOREIGN_INTR   4
+#define OPTEE_SMC_RETURN_RPC_FOREIGN_INTR \
+  OPTEE_SMC_RPC_VAL(OPTEE_SMC_RPC_FUNC_FOREIGN_INTR)
+
+/* Do an RPC request. The supplied struct optee_msg_arg tells which
+ * request to do and the parameters for the request. The following fields
+ * are used (the rest are unused):
+ * - cmd    the Request ID
+ * - ret    return value of the request, filled in by normal world
+ * - num_params    number of parameters for the request
+ * - params    the parameters
+ * - param_attrs  attributes of the parameters
+ *
+ * "Call" register usage:
+ * a0  OPTEE_SMC_RETURN_RPC_CMD
+ * a1  Upper 32bit of a 64bit Shared memory cookie holding a
+ *  struct optee_msg_arg, must be preserved, only the data should
+ *  be updated
+ * a2  Lower 32bit of a 64bit Shared memory cookie holding a
+ *  struct optee_msg_arg, must be preserved, only the data should
+ *  be updated
+ * a3-7  Resume information, must be preserved
+ *
+ * "Return" register usage:
+ * a0  SMC Function ID, OPTEE_SMC_CALL_RETURN_FROM_RPC.
+ * a1-2  Not used
+ * a3-7  Preserved
+ */
+#define OPTEE_SMC_RPC_FUNC_CMD            5
+#define OPTEE_SMC_RETURN_RPC_CMD \
+  OPTEE_SMC_RPC_VAL(OPTEE_SMC_RPC_FUNC_CMD)
+
+/* Returned in a0 */
+#define OPTEE_SMC_RETURN_UNKNOWN_FUNCTION 0xFFFFFFFF
+
+/* Returned in a0 only from Trusted OS functions */
+#define OPTEE_SMC_RETURN_OK               0x0
+#define OPTEE_SMC_RETURN_ETHREAD_LIMIT    0x1
+#define OPTEE_SMC_RETURN_EBUSY            0x2
+#define OPTEE_SMC_RETURN_ERESUME          0x3
+#define OPTEE_SMC_RETURN_EBADADDR         0x4
+#define OPTEE_SMC_RETURN_EBADCMD          0x5
+#define OPTEE_SMC_RETURN_ENOMEM           0x6
+#define OPTEE_SMC_RETURN_ENOTAVAIL        0x7
+#define OPTEE_SMC_RETURN_IS_RPC(ret)      optee_smc_return_is_rpc((ret))
+
+static inline bool optee_smc_return_is_rpc(uint32_t ret)
+{
+  return ret != OPTEE_SMC_RETURN_UNKNOWN_FUNCTION &&
+          (ret & OPTEE_SMC_RETURN_RPC_PREFIX_MASK) ==
+          OPTEE_SMC_RETURN_RPC_PREFIX;
+}
+
+#endif /* __DRIVERS_MISC_OPTEE_SMC_H */

--- a/drivers/misc/optee_socket.c
+++ b/drivers/misc/optee_socket.c
@@ -161,6 +161,7 @@ int optee_transport_open(FAR struct optee_priv_data **priv_)
       return ret;
     }
 
+  priv->base.alignment = 0;
   *priv_ = (FAR struct optee_priv_data *)priv;
   return 0;
 }

--- a/drivers/misc/optee_socket.c
+++ b/drivers/misc/optee_socket.c
@@ -1,0 +1,284 @@
+/****************************************************************************
+ * drivers/misc/optee_socket.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/arch.h>
+#include <nuttx/net/net.h>
+#include <nuttx/kmalloc.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/param.h>
+#include <sys/un.h>
+#include <netpacket/rpmsg.h>
+
+#include "optee.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define OPTEE_SOCKET_MAX_IOVEC_NUM            7
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct optee_socket_priv_data
+{
+  struct optee_priv_data base;
+  struct socket socket;
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int optee_socket_recv(FAR struct socket *psock, FAR void *msg,
+                             size_t size)
+{
+  while (size > 0)
+    {
+      ssize_t n = psock_recv(psock, msg, size, 0);
+      if (n <= 0)
+        {
+          return n < 0 ? n : -EIO;
+        }
+
+      size -= n;
+      msg = (FAR char *)msg + n;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: optee_transport_init
+ *
+ * Description:
+ *   Perform any initialization actions specific to the transport used
+ *   right before the driver is registered.
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int optee_transport_init(void)
+{
+  return 0;
+}
+
+/****************************************************************************
+ * Name: optee_transport_open
+ *
+ * Description:
+ *   Perform any transport-specific actions upon driver character device
+ *   open. In this case, open the socket and connect to it.
+ *
+ * Parameters:
+ *   priv_  - the optee_priv_data struct to allocate and return by
+ *            reference.
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int optee_transport_open(FAR struct optee_priv_data **priv_)
+{
+  FAR struct optee_socket_priv_data *priv;
+#ifdef CONFIG_DEV_OPTEE_LOCAL
+  struct sockaddr_un addr;
+#else
+  struct sockaddr_rpmsg addr;
+#endif
+  int ret;
+
+  priv = kmm_zalloc(sizeof(struct optee_socket_priv_data));
+  if (priv == NULL)
+    {
+      return -ENOMEM;
+    }
+
+#ifdef CONFIG_DEV_OPTEE_LOCAL
+  ret = psock_socket(AF_UNIX, SOCK_STREAM, 0, &priv->socket);
+#else
+  ret = psock_socket(AF_RPMSG, SOCK_STREAM, 0, &priv->socket);
+#endif
+  if (ret < 0)
+    {
+      kmm_free(priv);
+      return ret;
+    }
+
+  memset(&addr, 0, sizeof(addr));
+
+#ifdef CONFIG_DEV_OPTEE_LOCAL
+  addr.sun_family = AF_UNIX;
+  strlcpy(addr.sun_path, OPTEE_SERVER_PATH, sizeof(addr.sun_path));
+#else
+  addr.rp_family = AF_RPMSG;
+  strlcpy(addr.rp_name, OPTEE_SERVER_PATH, sizeof(addr.rp_name));
+  strlcpy(addr.rp_cpu, CONFIG_OPTEE_REMOTE_CPU_NAME, sizeof(addr.rp_cpu));
+#endif
+
+  ret = psock_connect(&priv->socket, (FAR const struct sockaddr *)&addr,
+                      sizeof(addr));
+  if (ret < 0)
+    {
+      psock_close(&priv->socket);
+      kmm_free(priv);
+      return ret;
+    }
+
+  *priv_ = (FAR struct optee_priv_data *)priv;
+  return 0;
+}
+
+/****************************************************************************
+ * Name: optee_transport_close
+ *
+ * Description:
+ *   Perform any transport-specific actions upon driver character device
+ *   close.
+ *
+ * Parameters:
+ *   priv_  - the optee_priv_data struct to close and de-allocate.
+ *
+ * Returned Values:
+ *   None
+ *
+ ****************************************************************************/
+
+void optee_transport_close(FAR struct optee_priv_data *priv_)
+{
+  FAR struct optee_socket_priv_data *priv =
+                  (FAR struct optee_socket_priv_data *)priv_;
+
+  psock_close(&priv->socket);
+  kmm_free(priv);
+}
+
+/****************************************************************************
+ * Name: optee_transport_call
+ *
+ * Description:
+ *   Call OP-TEE OS through the RPMsg/local socket.
+ *
+ * Parameters:
+ *   priv_  - the optee_priv_data struct to use
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int optee_transport_call(FAR struct optee_priv_data *priv_,
+                         FAR struct optee_msg_arg *arg)
+{
+  /* iov[0]: struct opteee_msg_arg + struct optee_msg_param[n]
+   * iov[1 - n+1]: shm_mem
+   * 0 <= n <= 6
+   */
+
+  FAR struct optee_socket_priv_data *priv =
+                  (FAR struct optee_socket_priv_data *)priv_;
+  size_t arg_size = OPTEE_MSG_GET_ARG_SIZE(arg->num_params);
+  size_t shm_size[OPTEE_MAX_PARAM_NUM];
+  size_t shm_addr[OPTEE_MAX_PARAM_NUM];
+  struct iovec iov[OPTEE_SOCKET_MAX_IOVEC_NUM];
+  struct msghdr msghdr;
+  unsigned long iovlen = 1;
+  unsigned long i;
+  int ret;
+
+  memset(iov, 0, sizeof(iov));
+  memset(shm_size, 0, sizeof(shm_size));
+
+  iov[0].iov_base = arg;
+  iov[0].iov_len = arg_size;
+
+  for (i = 0; i < arg->num_params; i++)
+    {
+      if (arg->params[i].attr == OPTEE_MSG_ATTR_TYPE_RMEM_INPUT ||
+          arg->params[i].attr == OPTEE_MSG_ATTR_TYPE_RMEM_INOUT)
+        {
+          iov[iovlen].iov_base =
+            (FAR void *)(uintptr_t)arg->params[i].u.rmem.shm_ref;
+          iov[iovlen].iov_len = arg->params[i].u.rmem.size;
+          shm_size[i] = arg->params[i].u.rmem.size;
+          shm_addr[i] = arg->params[i].u.rmem.shm_ref;
+          iovlen++;
+        }
+      else if (arg->params[i].attr == OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT)
+        {
+          shm_size[i] = arg->params[i].u.rmem.size;
+          shm_addr[i] = arg->params[i].u.rmem.shm_ref;
+        }
+    }
+
+  memset(&msghdr, 0, sizeof(struct msghdr));
+  msghdr.msg_iov = iov;
+  msghdr.msg_iovlen = iovlen;
+
+  ret = psock_sendmsg(&priv->socket, &msghdr, 0);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = optee_socket_recv(&priv->socket, arg, arg_size);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  for (i = 0; i < arg->num_params; i++)
+    {
+      if (arg->params[i].attr == OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT ||
+          arg->params[i].attr == OPTEE_MSG_ATTR_TYPE_RMEM_INOUT)
+        {
+          size_t size = MIN(arg->params[i].u.rmem.size, shm_size[i]);
+          arg->params[i].u.rmem.shm_ref = shm_addr[i];
+          ret = optee_socket_recv(&priv->socket,
+                                  (FAR void *)(uintptr_t)
+                                  arg->params[i].u.rmem.shm_ref, size);
+          if (ret < 0)
+            {
+              return ret;
+            }
+        }
+    }
+
+  return 0;
+}

--- a/include/imx_container.h
+++ b/include/imx_container.h
@@ -1,0 +1,129 @@
+/****************************************************************************
+ * include/imx_container.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_IMX_CONTAINER_H
+#define __INCLUDE_IMX_CONTAINER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IV_MAX_LEN                 32
+#define HASH_MAX_LEN               64
+
+#define CONTAINER_HDR_ALIGNMENT    0x400
+#define CONTAINER_HDR_EMMC_OFFSET  0
+#define CONTAINER_HDR_MMCSD_OFFSET SZ_32K
+#define CONTAINER_HDR_QSPI_OFFSET  SZ_4K
+#define CONTAINER_HDR_NAND_OFFSET  SZ_128M
+
+#define CONTAINER_HDR_TAG          0x87
+#define CONTAINER_HDR_VERSION      0
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* i.MX AHAB container header. */
+
+begin_packed_struct struct container_hdr
+{
+  uint8_t  version;
+  uint8_t  length_lsb;
+  uint8_t  length_msb;
+  uint8_t  tag;
+  uint32_t flags;
+  uint16_t sw_version;
+  uint8_t  fuse_version;
+  uint8_t  num_images;
+  uint16_t sig_blk_offset;
+  uint16_t reserved;
+} end_packed_struct;
+
+/* i.MX AHAB container, image header. */
+
+begin_packed_struct struct boot_img_hdr
+{
+  uint32_t offset;
+  uint32_t size;
+  uint64_t dst;
+  uint64_t entry;
+  uint32_t hab_flags;
+  uint32_t meta;
+  uint8_t  hash[HASH_MAX_LEN];
+  uint8_t  iv[IV_MAX_LEN];
+} end_packed_struct;
+
+/* i.MX AHAB container, signature block header. */
+
+begin_packed_struct struct signature_block_hdr
+{
+  uint8_t  version;
+  uint8_t  length_lsb;
+  uint8_t  length_msb;
+  uint8_t  tag;
+  uint16_t srk_table_offset;
+  uint16_t cert_offset;
+  uint16_t blob_offset;
+  uint16_t signature_offset;
+  uint32_t reserved;
+} end_packed_struct;
+
+/* Header used for the generation of an encrypted key blob from ELE. */
+
+begin_packed_struct struct generate_key_blob_hdr
+{
+  uint8_t version;
+  uint8_t length_lsb;
+  uint8_t length_msb;
+  uint8_t tag;
+  uint8_t flags;
+  uint8_t size;
+  uint8_t algorithm;
+  uint8_t mode;
+} end_packed_struct;
+
+/****************************************************************************
+ * Name: imx_valid_container_hdr
+ *
+ * Description:
+ *   Simple validation of the container header.
+ *
+ * Returned Value:
+ *   true for Success, otherwise false
+ *
+ ****************************************************************************/
+
+static inline bool imx_valid_container_hdr(struct container_hdr *container)
+{
+    return container->tag == CONTAINER_HDR_TAG &&
+           container->version == CONTAINER_HDR_VERSION;
+}
+#endif /* __INCLUDE_IMX_CONTAINER_H */

--- a/include/nuttx/tee.h
+++ b/include/nuttx/tee.h
@@ -198,6 +198,10 @@ struct tee_ioctl_shm_register_fd_data
 
 #define TEE_IOCTL_LOGIN_REE_KERNEL              0x80000000
 
+/* Macro to help calculate the total size of n params */
+
+#define TEE_IOCTL_PARAM_SIZE(x)                 (sizeof(struct tee_ioctl_param) * (x))
+
 /* struct tee_ioctl_param - parameter
  * attr: attributes
  * a: if a memref, offset into the shared memory object, else a value

--- a/include/nuttx/tee.h
+++ b/include/nuttx/tee.h
@@ -378,6 +378,13 @@ struct tee_iocl_supp_send_arg
 
 #define TEE_IOC_SUPPL_SEND _IOC(TEE_IOC_MAGIC << 8, TEE_IOC_BASE + 7)
 
+/* Shared memory specific defines */
+
+#define TEE_SHM_REGISTER     (1 << 0) /* In list of shared memory */
+#define TEE_SHM_SEC_REGISTER (1 << 1) /* TEE notified of this memory */
+#define TEE_SHM_ALLOC        (1 << 2) /* The memory is malloced() and must
+                                       * be freed() */
+
 /* struct tee_ioctl_shm_register_data - Shared memory register argument
  * addr:      [in] Start address of shared memory to register
  * length:    [in/out] Length of shared memory to register

--- a/include/nuttx/tee.h
+++ b/include/nuttx/tee.h
@@ -378,12 +378,10 @@ struct tee_iocl_supp_send_arg
 
 #define TEE_IOC_SUPPL_SEND _IOC(TEE_IOC_MAGIC << 8, TEE_IOC_BASE + 7)
 
-/* Shared memory specific defines */
+/* Shared memory-specific defines */
 
-#define TEE_SHM_REGISTER     (1 << 0) /* In list of shared memory */
-#define TEE_SHM_SEC_REGISTER (1 << 1) /* TEE notified of this memory */
-#define TEE_SHM_ALLOC        (1 << 2) /* The memory is malloced() and must
-                                       * be freed() */
+#define TEE_SHM_ALLOC    (1 << 0) /* Kernel-malloced and must freed */
+#define TEE_SHM_REGISTER (1 << 1) /* Registered with TEE OS */
 
 /* struct tee_ioctl_shm_register_data - Shared memory register argument
  * addr:      [in] Start address of shared memory to register

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -188,6 +188,7 @@ static const char *g_white_prefix[] =
   "ASCII_",  /* Ref:  include/nuttx/ascii.h */
   "Dl_info", /* Ref:  include/dlfcn.h */
   "Elf",     /* Ref:  include/elf.h, include/elf32.h, include/elf64.h */
+  "Ifx",     /* Ref:  arch/tricore/src */
   "PRId",    /* Ref:  inttypes.h */
   "PRIi",    /* Ref:  inttypes.h */
   "PRIo",    /* Ref:  inttypes.h */
@@ -200,6 +201,8 @@ static const char *g_white_prefix[] =
   "SCNx",    /* Ref:  inttypes.h */
   "SYS_",    /* Ref:  include/sys/syscall.h */
   "STUB_",   /* Ref:  syscall/syscall_lookup.h, syscall/sycall_stublookup.c */
+  "TEEC_",   /* Ref:  apps/tee/libteec/optee_client/libteec/include/tee_client_api.h */
+  "V4L2_",   /* Ref:  include/sys/video_controls.h */
   "XK_",     /* Ref:  include/input/X11_keysymdef.h */
   "b8",      /* Ref:  include/fixedmath.h */
   "b16",     /* Ref:  include/fixedmath.h */
@@ -210,8 +213,6 @@ static const char *g_white_prefix[] =
   "ub32",    /* Ref:  include/fixedmath.h */
   "lua_",    /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lua.h */
   "luaL_",   /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lauxlib.h */
-  "V4L2_",   /* Ref:  include/sys/video_controls.h */
-  "Ifx",     /* Ref:  arch/tricore/src */
   NULL
 };
 
@@ -627,6 +628,16 @@ static const char *g_white_content_list[] =
   "inflateInit",
   "inflateEnd",
   "zError",
+
+  /* Ref:
+   * apps/tee/libteec/optee_client/libteec/include/tee_client_api.h
+   */
+
+  "clockSeqAndNode",
+  "paramTypes",
+  "timeLow",
+  "timeMid",
+  "timeHiAndVersion",
 
   NULL
 };


### PR DESCRIPTION
## Description
This PR includes cherry-picked commits from the upstream, apache nuttx repo, that haven't been merged yet.
The main functionality these commits bring is:

-  ELE functionality to support AHAB boot and TRNG (True Random Number Generator).
- Introduce the imx9 ROMAPI which is currently required by the AHAB boot, and decouples the boot media from the bootloader firmware.
- imx9 AHAB boot API.
- Option to disable MMU (this was necessary for the stripped down version of the bl2 bootloader).
- Ability to build an imx9 bootloader either in EL3(bl2) or EL1(bl33) (before this PR, only EL3 builds were allowed).
- OP-TEE smc driver, to enable communication between the non-secure and the secure world.
- OP-TEE driver for shared memory allocation and registration.

