### PR TITLE
Revert "imx9/lpuart: Fix SMP deadlock with imx9_txint"

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -2358,7 +2358,6 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   imx9_serialout(priv, IMX9_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(&priv->lock, flags);
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
   if (enable)
@@ -2366,6 +2365,8 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
       uart_xmitchars(dev);
     }
 #endif
+
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 #endif
 


### PR DESCRIPTION
This reverts commit 83a119160c03f5910bd76ab07c9e19cbfa1e82d4.

This commit broke the GPS; the issue needs more investigation
