### PR TITLE
Imx9 fix lpuart for smp

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -2340,6 +2340,13 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   irqstate_t flags;
   uint32_t regval;
 
+#ifndef CONFIG_SUPPRESS_SERIAL_INTS
+  if (enable)
+    {
+      uart_xmitchars(dev);
+    }
+#endif
+
   /* Enable interrupt for TX complete */
 
   flags = spin_lock_irqsave(&priv->lock);
@@ -2359,13 +2366,6 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   regval |= priv->ie;
   imx9_serialout(priv, IMX9_LPUART_CTRL_OFFSET, regval);
   spin_unlock_irqrestore(&priv->lock, flags);
-
-#ifndef CONFIG_SUPPRESS_SERIAL_INTS
-  if (enable)
-    {
-      uart_xmitchars(dev);
-    }
-#endif
 }
 #endif
 

--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -2358,6 +2358,7 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   imx9_serialout(priv, IMX9_LPUART_CTRL_OFFSET, regval);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
   if (enable)
@@ -2365,8 +2366,6 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
       uart_xmitchars(dev);
     }
 #endif
-
-  spin_unlock_irqrestore(&priv->lock, flags);
 }
 #endif
 


### PR DESCRIPTION
I had to revert one of SMP related lpuart commits earlier, because it broke the uart in single CPU

This reverts that revert, and adds a fix for the original issue. After this, the SMP boots ok on imx9
