### PR TITLE
Imx9 fix lpuart init

### DIFF
--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -201,12 +201,6 @@ void arm64_chip_boot(void)
   imx9_gpioirq_initialize();
 #endif
 
-  /* Perform board-specific device initialization. This would include
-   * configuration of board specific resources such as GPIOs, LEDs, etc.
-   */
-
-  imx9_board_initialize();
-
 #ifdef USE_EARLYSERIALINIT
   /* Perform early serial initialization if we are going to use the serial
    * driver.
@@ -214,4 +208,10 @@ void arm64_chip_boot(void)
 
   arm64_earlyserialinit();
 #endif
+
+  /* Perform board-specific device initialization. This would include
+   * configuration of board specific resources such as GPIOs, LEDs, etc.
+   */
+
+  imx9_board_initialize();
 }

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -174,13 +174,6 @@ void arm64_chip_boot(void)
 
   imx9_clockconfig();
 
-#ifdef CONFIG_IMX9_LPUART
-
-  /* Do UART early initialization & pin muxing */
-
-  imx9_lowsetup();
-#endif
-
 #ifdef CONFIG_IMX9_DDR_TRAINING
   imx9_dram_init();
 #endif
@@ -190,6 +183,12 @@ void arm64_chip_boot(void)
   /* MAP IO and DRAM, enable MMU. */
 
   arm64_mmu_init(true);
+#endif
+
+  /* Do UART early initialization & pin muxing */
+
+#ifdef CONFIG_IMX9_LPUART
+  imx9_lowsetup();
 #endif
 
 #if defined(CONFIG_ARM64_PSCI)
@@ -202,6 +201,12 @@ void arm64_chip_boot(void)
   imx9_gpioirq_initialize();
 #endif
 
+  /* Perform board-specific device initialization. This would include
+   * configuration of board specific resources such as GPIOs, LEDs, etc.
+   */
+
+  imx9_board_initialize();
+
 #ifdef USE_EARLYSERIALINIT
   /* Perform early serial initialization if we are going to use the serial
    * driver.
@@ -209,10 +214,4 @@ void arm64_chip_boot(void)
 
   arm64_earlyserialinit();
 #endif
-
-  /* Perform board-specific device initialization. This would include
-   * configuration of board specific resources such as GPIOs, LEDs, etc.
-   */
-
-  imx9_board_initialize();
 }


### PR DESCRIPTION
## Summary

Move uart low init from bl2 only to original place

## Impact

Imx9 boot and uart

## Testing

Custom imx9 hardware
IMX9 PX4 uarts are again working 
