### PR TITLE
arch/mpfs: Add I2C extension IP support

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -411,6 +411,48 @@ config MPFS_COREI2C_IRQNUM
 	range 0 63
 	depends on MPFS_COREI2C
 
+config MPFS_COREI2C0_EXTENSION
+	bool "CoreI2C instance 0 uses extension IP"
+	default n
+	depends on MPFS_COREI2C
+	depends on MPFS_COREI2C_INSTANCES > 0
+
+config MPFS_COREI2C1_EXTENSION
+	bool "CoreI2C instance 1 uses extension IP"
+	default n
+	depends on MPFS_COREI2C
+	depends on MPFS_COREI2C_INSTANCES > 1
+
+config MPFS_COREI2C2_EXTENSION
+	bool "CoreI2C instance 2 uses extension IP"
+	default n
+	depends on MPFS_COREI2C
+	depends on MPFS_COREI2C_INSTANCES > 2
+
+config MPFS_COREI2C3_EXTENSION
+	bool "CoreI2C instance 3 uses extension IP"
+	default n
+	depends on MPFS_COREI2C
+	depends on MPFS_COREI2C_INSTANCES > 3
+
+config MPFS_COREI2C4_EXTENSION
+	bool "CoreI2C instance 4 uses extension IP"
+	default n
+	depends on MPFS_COREI2C
+	depends on MPFS_COREI2C_INSTANCES > 4
+
+config MPFS_COREI2C5_EXTENSION
+	bool "CoreI2C instance 5 uses extension IP"
+	default n
+	depends on MPFS_COREI2C
+	depends on MPFS_COREI2C_INSTANCES > 5
+
+config MPFS_COREI2C7_EXTENSION
+	bool "CoreI2C instance 7 uses extension IP"
+	default n
+	depends on MPFS_COREI2C
+	depends on MPFS_COREI2C_INSTANCES > 7
+
 config MPFS_EMMCSD
 	bool "EMMCSD"
 	select ARCH_HAVE_SDIO

--- a/arch/risc-v/src/mpfs/hardware/mpfs_i2c_ext.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_i2c_ext.h
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/hardware/mpfs_i2c_ext.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_MPFS_HARDWARE_MPFS_I2C_EXT_H
+#define __ARCH_RISCV_SRC_MPFS_HARDWARE_MPFS_I2C_EXT_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* I2C extension IP registers */
+
+#define MPFS_COREI2C_EXT_CTR_OFFSET     0x20
+#define MPFS_COREI2C_EXT_STA_OFFSET     0x24
+#define MPFS_COREI2C_EXT_DAT_OFFSET     0x28
+#define MPFS_COREI2C_EXT_ADR_OFFSET     0x2c
+#define MPFS_COREI2C_EXT_BTT_OFFSET     0x30
+#define MPFS_COREI2C_EXT_CNF_OFFSET     0x34
+#define MPFS_COREI2C_EXT_TMR_OFFSET     0x38
+#define MPFS_COREI2C_EXT_IRQ_OFFSET     0x3c
+
+/* I2C extension IP register bits */
+
+#define MPFS_COREI2C_EXT_CTR_ENABLE     (1 << 0)
+#define MPFS_COREI2C_EXT_CTR_START      (1 << 1)
+#define MPFS_COREI2C_EXT_CTR_STOP       (1 << 2)
+
+#define MPFS_COREI2C_EXT_STA_ENABLE     (1 << 0)
+#define MPFS_COREI2C_EXT_STA_ACTIVE     (1 << 1)
+#define MPFS_COREI2C_EXT_STA_INT        (1 << 2)
+#define MPFS_COREI2C_EXT_STA_TXCOUNT(x) (((x) >> 8)  & 0xff)
+#define MPFS_COREI2C_EXT_STA_RXCOUNT(x) (((x) >> 16) & 0xff)
+
+#define MPFS_COREI2C_EXT_BTT_TX(x)      ((x) & 0x3f)
+#define MPFS_COREI2C_EXT_BTT_RX(x)      (((x) & 0x3f) << 8)
+
+#define MPFS_COREI2C_EXT_CNF_M_READ     (1 << 0)
+#define MPFS_COREI2C_EXT_CNF_M_TEN      (1 << 1)
+#define MPFS_COREI2C_EXT_CNF_M_CONT     (1 << 5)
+#define MPFS_COREI2C_EXT_CNF_M_NOSTOP   (1 << 6)
+#define MPFS_COREI2C_EXT_CNF_M_NOSTART  (1 << 7)
+#define MPFS_COREI2C_EXT_CNF_IRQ_ENABLE (1 << 8)
+#define MPFS_COREI2C_EXT_CNF_IRQ_MASK   (1 << 9)
+
+#define MPFS_COREI2C_EXT_IRQ_COMPLETE   (1 << 0)
+#define MPFS_COREI2C_EXT_IRQ_ERROR      (1 << 1)
+#define MPFS_COREI2C_EXT_IRQ_BUS_ERROR  (1 << 2)
+#define MPFS_COREI2C_EXT_IRQ_TX_OVF     (1 << 3)
+#define MPFS_COREI2C_EXT_IRQ_TX_UDR     (1 << 4)
+#define MPFS_COREI2C_EXT_IRQ_RX_OVF     (1 << 5)
+#define MPFS_COREI2C_EXT_IRQ_RX_UDR     (1 << 6)
+#define MPFS_COREI2C_EXT_IRQ_STATUS(x)  (((x) >> 8) & 0xff)
+
+#endif /* __ARCH_RISCV_SRC_MPFS_HARDWARE_MPFS_I2C_EXT_H */

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -51,6 +51,7 @@
 #include "mpfs_rcc.h"
 #include "riscv_internal.h"
 #include "hardware/mpfs_i2c.h"
+#include "hardware/mpfs_i2c_ext.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -73,10 +74,25 @@
 #define MPFS_I2C_DATA             (priv->hw_base + MPFS_I2C_DATA_OFFSET)
 #define MPFS_I2C_ADDR             (priv->hw_base + MPFS_I2C_SLAVE0ADR_OFFSET)
 
+/* MPFS CoreI2C extension IP registers */
+
+#define MPFS_COREI2C_EXT_CTR      (priv->hw_base + MPFS_COREI2C_EXT_CTR_OFFSET)
+#define MPFS_COREI2C_EXT_STA      (priv->hw_base + MPFS_COREI2C_EXT_STA_OFFSET)
+#define MPFS_COREI2C_EXT_DAT      (priv->hw_base + MPFS_COREI2C_EXT_DAT_OFFSET)
+#define MPFS_COREI2C_EXT_ADR      (priv->hw_base + MPFS_COREI2C_EXT_ADR_OFFSET)
+#define MPFS_COREI2C_EXT_BTT      (priv->hw_base + MPFS_COREI2C_EXT_BTT_OFFSET)
+#define MPFS_COREI2C_EXT_CNF      (priv->hw_base + MPFS_COREI2C_EXT_CNF_OFFSET)
+#define MPFS_COREI2C_EXT_TMR      (priv->hw_base + MPFS_COREI2C_EXT_TMR_OFFSET)
+#define MPFS_COREI2C_EXT_IRQ      (priv->hw_base + MPFS_COREI2C_EXT_IRQ_OFFSET)
+
 /* Gives TTOA in microseconds, ~4.8% bias, +1 rounds up */
 
 #define I2C_TTOA_US(n, f)           ((((n) << 20) / (f)) + 1)
 #define I2C_TTOA_MARGIN             1000u
+
+/* MPFS CoreI2C extension IP fifo size */
+
+#define MPFS_COREI2C_EXT_FIFO_SZ    63
 
 /****************************************************************************
  * Private Types
@@ -131,6 +147,7 @@ static const uint32_t mpfs_i2c_freqs_fpga[MPFS_I2C_NUMBER_OF_DIVIDERS] =
 };
 
 static int mpfs_i2c_irq(int cpuint, void *context, void *arg);
+static int mpfs_i2c_ext_irq(int cpuint, void *context, void *arg);
 
 static int mpfs_i2c_transfer(struct i2c_master_s *dev,
                              struct i2c_msg_s *msgs,
@@ -179,6 +196,7 @@ struct mpfs_i2c_priv_s
 
   bool                   initialized; /* Bus initialization status */
   bool                   fpga;        /* FPGA i2c */
+  bool                   ext;         /* Uses extension IP */
   bool                   inflight;    /* Transfer ongoing */
 };
 
@@ -239,40 +257,80 @@ static struct mpfs_i2c_priv_s
 {
   {
     .lock           = NXMUTEX_INITIALIZER,
+#  ifdef CONFIG_MPFS_COREI2C0_EXTENSION
+    .ext            = true,
+#  else
+    .ext            = false,
+#  endif
   },
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 1)
   {
     .lock           = NXMUTEX_INITIALIZER,
+#    ifdef CONFIG_MPFS_COREI2C1_EXTENSION
+    .ext            = true,
+#    else
+    .ext            = false,
+#    endif
   },
 #  endif
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 2)
   {
     .lock           = NXMUTEX_INITIALIZER,
+#    ifdef CONFIG_MPFS_COREI2C2_EXTENSION
+    .ext            = true,
+#    else
+    .ext            = false,
+#    endif
   },
 #  endif
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 3)
   {
     .lock           = NXMUTEX_INITIALIZER,
+#    ifdef CONFIG_MPFS_COREI2C3_EXTENSION
+    .ext            = true,
+#    else
+    .ext            = false,
+#    endif
   },
 #endif
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 4)
   {
     .lock           = NXMUTEX_INITIALIZER,
+#    ifdef CONFIG_MPFS_COREI2C4_EXTENSION
+    .ext            = true,
+#    else
+    .ext            = false,
+#    endif
   },
 #  endif
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 5)
   {
     .lock           = NXMUTEX_INITIALIZER,
+#    ifdef CONFIG_MPFS_COREI2C5_EXTENSION
+    .ext            = true,
+#    else
+    .ext            = false,
+#    endif
   },
 #  endif
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 6)
   {
     .lock           = NXMUTEX_INITIALIZER,
+#    ifdef CONFIG_MPFS_COREI2C6_EXTENSION
+    .ext            = true,
+#    else
+    .ext            = false,
+#    endif
   },
 #  endif
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 7)
     {
     .lock           = NXMUTEX_INITIALIZER,
+#    ifdef CONFIG_MPFS_COREI2C7_EXTENSION
+    .ext            = true,
+#    else
+    .ext            = false,
+#    endif
     },
 #  endif
 #  if (CONFIG_MPFS_COREI2C_INSTANCES > 8)
@@ -362,7 +420,8 @@ static int mpfs_i2c_init(struct mpfs_i2c_priv_s *priv)
 
       /* Attach interrupt */
 
-      ret = irq_attach(priv->plic_irq, mpfs_i2c_irq, priv);
+      ret = irq_attach(priv->plic_irq,
+                       priv->ext ? mpfs_i2c_ext_irq : mpfs_i2c_irq, priv);
       if (ret != OK)
         {
           return ret;
@@ -481,6 +540,191 @@ static int mpfs_i2c_sem_waitdone(struct mpfs_i2c_priv_s *priv)
 {
   uint32_t timeout = mpfs_i2c_timeout(priv->msgc, priv->msgv);
   return nxsem_tickwait_uninterruptible(&priv->sem_isr, USEC2TICK(timeout));
+}
+
+static void mpfs_i2c_ext_transfer(struct mpfs_i2c_priv_s *priv)
+{
+  uint32_t flags = 0;
+  struct i2c_msg_s *msg = &priv->msgv[priv->msgid];
+  int txsize;
+  int rxsize;
+  int tx_fifo_bytes;
+  int rx_fifo_bytes;
+  int i;
+
+  /* Configure bytes left to transfer, up to 63 bytes */
+
+  txsize = (priv->tx_size - priv->tx_idx);
+
+  /* If this is a combined tx+rx, but TX is larger than 63 bytes,
+   * keep RX bytes 0 until all the TX can be sent
+   */
+
+  if (txsize <= MPFS_COREI2C_EXT_FIFO_SZ)
+    {
+      rxsize = priv->rx_size - priv->rx_idx;
+      tx_fifo_bytes = txsize;
+    }
+  else
+    {
+      rxsize = 0;
+      tx_fifo_bytes = MPFS_COREI2C_EXT_FIFO_SZ;
+    }
+
+  rx_fifo_bytes =
+    rxsize < MPFS_COREI2C_EXT_FIFO_SZ ? rxsize : MPFS_COREI2C_EXT_FIFO_SZ;
+
+  putreg32(MPFS_COREI2C_EXT_BTT_TX(tx_fifo_bytes) |
+           MPFS_COREI2C_EXT_BTT_RX(rx_fifo_bytes),
+           MPFS_COREI2C_EXT_BTT);
+
+  /* Set flags, M_READ, IRQ_ENABLE, M_CONT and M_NOSTOP */
+
+  if (msg->flags & I2C_M_READ)
+    {
+      flags |= MPFS_COREI2C_EXT_CNF_M_READ;
+    }
+
+  flags |= MPFS_COREI2C_EXT_CNF_IRQ_ENABLE;
+
+  if (txsize > MPFS_COREI2C_EXT_FIFO_SZ || rxsize > MPFS_COREI2C_EXT_FIFO_SZ)
+    {
+      flags |= MPFS_COREI2C_EXT_CNF_M_CONT;
+    }
+
+  if (msg->flags & I2C_M_NOSTOP && txsize <= MPFS_COREI2C_EXT_FIFO_SZ)
+    {
+      flags |= MPFS_COREI2C_EXT_CNF_M_NOSTOP;
+    }
+
+  putreg32(flags, MPFS_COREI2C_EXT_CNF);
+
+  /* Configure slave address */
+
+  putreg32(msg->addr, MPFS_COREI2C_EXT_ADR);
+
+  /* Fill in TX fifo */
+
+  for (i = 0; i < tx_fifo_bytes; i++)
+    {
+      putreg8(priv->tx_buffer[priv->tx_idx + i], MPFS_COREI2C_EXT_DAT);
+    }
+
+  /* Set timeout */
+
+  putreg32(0x8000, MPFS_COREI2C_EXT_TMR);
+
+  /* Start transfer */
+
+  putreg32(MPFS_COREI2C_EXT_CTR_ENABLE | MPFS_COREI2C_EXT_CTR_START,
+           MPFS_COREI2C_EXT_CTR);
+}
+
+/****************************************************************************
+ * Name: mpfs_i2c_ext_irq
+ *
+ * Description:
+ *   This is the I2C extension interrupt handler. It will be invoked when an
+ *   interrupt is received on the device.
+ *
+ * Parameters:
+ *   cpuint        - CPU interrupt index
+ *   context       - Context data from the ISR
+ *   arg           - Opaque pointer to the internal driver state structure.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int mpfs_i2c_ext_irq(int cpuint, void *context, void *arg)
+{
+  struct mpfs_i2c_priv_s *priv = (struct mpfs_i2c_priv_s *)arg;
+  struct i2c_msg_s *msg = &priv->msgv[priv->msgid];
+  uint32_t status = getreg32(MPFS_COREI2C_EXT_IRQ);
+  uint32_t counts = getreg32(MPFS_COREI2C_EXT_STA);
+  int txbytes = MPFS_COREI2C_EXT_STA_TXCOUNT(counts);
+  int rxbytes = MPFS_COREI2C_EXT_STA_RXCOUNT(counts);
+
+  /* Clear interrupt */
+
+  putreg32(1, MPFS_COREI2C_EXT_IRQ);
+
+  if (txbytes > 0 || rxbytes > 0)
+    {
+      priv->tx_idx += txbytes;
+
+      if (priv->tx_idx >= priv->tx_size)
+        {
+          /* All TX sent (or nothing to send), handle RX */
+
+          int i;
+          int rx_end = priv->rx_idx + rxbytes;
+
+          /* Make sure that we don't overflow the buffer */
+
+          if (rx_end > priv->rx_size)
+            {
+              i2cerr("ERROR: %d extra bytes received?\n",
+                     rx_end - priv->rx_size);
+              rx_end = priv->rx_size;
+            }
+
+          /* Read out the RX data (if any) from the fifo */
+
+          for (i = priv->rx_idx; i < rx_end; i++)
+            {
+              priv->rx_buffer[i] = getreg8(MPFS_COREI2C_EXT_DAT);
+            }
+
+          priv->rx_idx = i;
+
+          if (priv->rx_idx >= priv->rx_size)
+            {
+              if (msg->flags & I2C_M_NOSTOP)
+                {
+                  /* Jump to the next message */
+
+                  if (priv->msgid < (priv->msgc - 1))
+                    {
+                      priv->msgid++;
+                    }
+                }
+
+              /* All RX received (or no RX to receive) */
+
+              priv->status = MPFS_I2C_SUCCESS;
+            }
+          else
+            {
+              /* Continue receive */
+
+              mpfs_i2c_ext_transfer(priv);
+            }
+        }
+      else
+        {
+          /* More TX to send */
+
+          mpfs_i2c_ext_transfer(priv);
+        }
+    }
+  else
+    {
+      /* Some errors occured, transfer failed */
+
+      priv->status = MPFS_I2C_FAILED;
+      i2cerr("ERROR: txbytes %d rxbytes %d, sta %x\n", txbytes, rxbytes,
+             status);
+    }
+
+  if (priv->status != MPFS_I2C_IN_PROGRESS)
+    {
+      nxsem_post(&priv->sem_isr);
+    }
+
+  return 0;
 }
 
 /****************************************************************************
@@ -769,7 +1013,14 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
 static void mpfs_i2c_sendstart(struct mpfs_i2c_priv_s *priv)
 {
-  modifyreg32(MPFS_I2C_CTRL, 0, MPFS_I2C_CTRL_STA_MASK);
+  if (priv->ext)
+    {
+      mpfs_i2c_ext_transfer(priv);
+    }
+  else
+    {
+      modifyreg32(MPFS_I2C_CTRL, 0, MPFS_I2C_CTRL_STA_MASK);
+    }
 }
 
 /****************************************************************************
@@ -852,6 +1103,14 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
           ret = -EAGAIN;
           goto errout_with_mutex;
         }
+    }
+
+  if (priv->ext)
+    {
+      /* Enable I2C extension */
+
+      putreg32(MPFS_COREI2C_EXT_CTR_ENABLE | MPFS_COREI2C_EXT_CTR_STOP,
+               MPFS_COREI2C_EXT_CTR);
     }
 
   priv->msgv = msgs;
@@ -968,6 +1227,13 @@ static int mpfs_i2c_transfer(struct i2c_master_s *dev,
   /* Disable interrupts and get out */
 
   up_disable_irq(priv->plic_irq);
+
+  if (priv->ext)
+    {
+      /* Disable I2C extension */
+
+      putreg32(MPFS_COREI2C_EXT_CTR_STOP, MPFS_COREI2C_EXT_CTR);
+    }
 
 errout_with_mutex:
   nxmutex_unlock(&priv->lock);


### PR DESCRIPTION
This adds the I2C extension support to the CoreI2C, enabling smart FIFO reads & writes
