### PR TITLE
arch/arm64: handle fatal user exception

### DIFF
--- a/arch/arm64/src/common/arm64_fatal.c
+++ b/arch/arm64/src/common/arm64_fatal.c
@@ -477,6 +477,112 @@ static int arm64_el1_exception_handler(uint64_t esr,
   return ret;
 }
 
+static void arm64_get_exception_info(uint64_t el, uint64_t *esr,
+                                     uint64_t *far, uint64_t *elr,
+                                     const char **el_str)
+{
+  switch (el)
+    {
+      case MODE_EL1:
+        {
+          if (el_str != NULL)
+            {
+              *el_str = "MODE_EL1";
+            }
+
+          if (esr != NULL)
+            {
+              *esr = read_sysreg(esr_el1);
+            }
+
+          if (far != NULL)
+            {
+              *far = read_sysreg(far_el1);
+            }
+
+          if (elr != NULL)
+            {
+              *elr = read_sysreg(elr_el1);
+            }
+          break;
+        }
+
+      case MODE_EL2:
+        {
+          if (el_str != NULL)
+            {
+              *el_str = "MODE_EL2";
+            }
+
+          if (esr != NULL)
+            {
+              *esr = read_sysreg(esr_el2);
+            }
+
+          if (far != NULL)
+            {
+              *far = read_sysreg(far_el2);
+            }
+
+          if (elr != NULL)
+            {
+              *elr = read_sysreg(elr_el2);
+            }
+          break;
+        }
+
+#ifdef CONFIG_ARCH_HAVE_EL3
+      case MODE_EL3:
+        {
+          if (el_str != NULL)
+            {
+              *el_str = "MODE_EL3";
+            }
+
+          if (esr != NULL)
+            {
+              *esr = read_sysreg(esr_el3);
+            }
+
+          if (far != NULL)
+            {
+              *far = read_sysreg(far_el3);
+            }
+
+          if (elr != NULL)
+            {
+              *elr = read_sysreg(elr_el3);
+            }
+          break;
+        }
+#endif
+
+      default:
+        {
+          if (el_str != NULL)
+            {
+              *el_str = "Unknown";
+            }
+
+          if (esr != NULL)
+            {
+              *esr = 0;
+            }
+
+          if (far != NULL)
+            {
+              *far = 0;
+            }
+
+          if (elr != NULL)
+            {
+              *elr = 0;
+            }
+          break;
+        }
+    }
+}
+
 static int arm64_exception_handler(uint64_t *regs)
 {
   uint64_t    el;
@@ -487,49 +593,21 @@ static int arm64_exception_handler(uint64_t *regs)
   int         ret = -EINVAL;
 
   el = arm64_current_el();
+  arm64_get_exception_info(el, &esr, &far, &elr, &el_str);
 
   switch (el)
-  {
-    case MODE_EL1:
     {
-      el_str = "MODE_EL1";
-      esr    = read_sysreg(esr_el1);
-      far    = read_sysreg(far_el1);
-      elr    = read_sysreg(elr_el1);
-      ret    = arm64_el1_exception_handler(esr, regs);
-      break;
+      case MODE_EL1:
+        {
+          ret = arm64_el1_exception_handler(esr, regs);
+          break;
+        }
+
+      default:
+        {
+          break;
+        }
     }
-
-    case MODE_EL2:
-    {
-      el_str = "MODE_EL2";
-      esr    = read_sysreg(esr_el2);
-      far    = read_sysreg(far_el2);
-      elr    = read_sysreg(elr_el2);
-      break;
-    }
-
-#ifdef CONFIG_ARCH_HAVE_EL3
-    case MODE_EL3:
-    {
-      el_str = "MODE_EL3";
-      esr    = read_sysreg(esr_el3);
-      far    = read_sysreg(far_el3);
-      elr    = read_sysreg(elr_el3);
-      break;
-    }
-
-#endif
-    default:
-    {
-      el_str = "Unknown";
-
-      /* Just to keep the compiler happy */
-
-      esr = elr = far = 0;
-      break;
-    }
-  }
 
   if (ret != 0)
     {
@@ -567,9 +645,47 @@ uint64_t *arm64_fatal_handler(uint64_t *regs)
 
   if (ret != 0)
     {
-      /* The fatal is not handled, print error and hung */
+      if (((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) &&
+          ((tcb->flags & TCB_FLAG_SYSCALL) == 0) &&
+          ((regs[REG_SPSR] & SPSR_MODE_MASK) == SPSR_MODE_EL0T))
+        {
+          uint64_t esr;
+          const char *reason;
+          const char *desc;
 
-      PANIC_WITH_REGS("panic", regs);
+          arm64_get_exception_info(arm64_current_el(), &esr, NULL,
+                                   NULL, NULL);
+
+          reason = esr_get_class_string(esr);
+          if (reason == NULL)
+            {
+              reason = "Unknown/Uncategorized";
+            }
+
+          desc = esr_get_desc_string(esr);
+          if (desc == NULL)
+            {
+              desc = "";
+            }
+
+          _alert("PANIC: Unhandled user exception in PID %d: %s\n",
+                 tcb->pid, get_task_name(tcb));
+          _alert("Reason: %s - %s\n", reason, desc);
+          up_dump_register(regs);
+
+          tcb->flags |= TCB_FLAG_FORCED_CANCEL;
+
+          regs[REG_ELR] = (uint64_t) _exit;
+          regs[REG_X0] = SIGSEGV;
+          regs[REG_SPSR] &= ~SPSR_MODE_MASK;
+          regs[REG_SPSR] |= SPSR_MODE_EL1H;
+        }
+      else
+        {
+          /* The fatal is not handled, print error and hung */
+
+          PANIC_WITH_REGS("panic", regs);
+        }
     }
 
   /* Clear irq flag */


### PR DESCRIPTION
## Summary

Add handler for unhandled user exception. Print exception reason class and description and dump registers.

## Impact

When user application/module panics the system does not halt, but only the user process exits.

## Testing

Added null pointer reference into one user module to cause user exception
When panic occurs, following is printed into the console:
```
[CPU0] arm64_fatal_handler: PANIC: Unhandled user exception in PID 23: commander
[CPU0] arm64_fatal_handler: Reason: DABT (lower EL) - Data Abort from a lower Exception level, that might be using AArch32 or AArch64
[CPU0] up_dump_register: stack = 0x809a2500
[CPU0] up_dump_register: x0:   0x0                 x1:   0xc0032cd8
[CPU0] up_dump_register: x2:   0x0                 x3:   0x0
[CPU0] up_dump_register: x4:   0x8000000000000000  x5:   0x0
[CPU0] up_dump_register: x6:   0x80                x7:   0xff62686d606ffefe
[CPU0] up_dump_register: x8:   0x7f7f7f7f7f7fffff  x9:   0x0
[CPU0] up_dump_register: x10:  0x101010101010101   x11:  0x38
[CPU0] up_dump_register: x12:  0x101010101010101   x13:  0x8
[CPU0] up_dump_register: x14:  0xffffffffffffffe   x15:  0x10
[CPU0] up_dump_register: x16:  0x17                x17:  0x0
[CPU0] up_dump_register: x18:  0x0                 x19:  0xc200aee0
[CPU0] up_dump_register: x20:  0x1                 x21:  0xc200af5a
[CPU0] up_dump_register: x22:  0xc200aed8          x23:  0xc0031810
[CPU0] up_dump_register: x24:  0xc00317df          x25:  0xa
[CPU0] up_dump_register: x26:  0x9                 x27:  0x2
[CPU0] up_dump_register: x28:  0x0                 x29:  0x0
[CPU0] up_dump_register: x30:  0xc000d704        
[CPU0] up_dump_register: 
[CPU0] up_dump_register: STATUS Registers:
[CPU0] up_dump_register: SPSR:      0x0               
[CPU0] up_dump_register: ELR:       0xc000d70c        
[CPU0] up_dump_register: SP_EL0:    0xc200ad80        
[CPU0] up_dump_register: SP_ELX:    0x809a2840        
[CPU0] up_dump_register: EXE_DEPTH: 0xffffffffffffffc4
[CPU0] up_dump_register: SCTLR_EL1: 0x30d0180d        
saluki>
```
user process exits and nsh shell is alive
