### PR TITLE
arch/imx9: Increase SPI root clocks to 125MHz

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpspi.c
+++ b/arch/arm64/src/imx9/imx9_lpspi.c
@@ -2026,6 +2026,10 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
   if (priv->refcount == 0)
     {
+      /* Set clock root to 125MHz */
+
+      imx9_ccm_configure_root_clock(priv->clk_root, SYS_PLL1PFD0DIV2, 4);
+
       imx9_lpspi_bus_initialize(priv);
     }
 


### PR DESCRIPTION
This change makes SPI clock calculation more precise




