### PR TITLE
fs/vfs/fs_lock.c: Close stale locks unconditionally

### DIFF
--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -784,7 +784,11 @@ void file_closelk(FAR struct file *filep)
       return;
     }
 
-  ret = file_lock_get_path(filep, path);
+  /* No need for inode type and signal handler context (e.g. "kill") checking
+   * here, but just get path unconditionally.
+   */
+
+  ret = file_fcntl(filep, F_GETPATH, path);
   if (ret < 0)
     {
       /* It isn't an error if fs doesn't support F_GETPATH, so we just end


### PR DESCRIPTION
## Summary

Allow to close the lock even the dying task is in signal handler context.
This patch prevents file locks to be locked by already killed task.

## Impact

File can be locked by new task when previous lock owner has been killed/crashed.

## Testing

1. File lock acquired by task
2. Task that has the file lock is killed
3. Spawn new task which acquires the lock for the same file

