### PR TITLE
syscall: fcntl param3 type to uintptr_t

### DIFF
--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -30,7 +30,7 @@
 "execve","unistd.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char * const []|FAR char * const *","FAR char * const []|FAR char * const *"
 "fchmod","sys/stat.h","","int","int","mode_t"
 "fchown","unistd.h","","int","int","uid_t","gid_t"
-"fcntl","fcntl.h","","int","int","int","...","int"
+"fcntl","fcntl.h","","int","int","int","...","uintptr_t"
 "fstat","sys/stat.h","","int","int","FAR struct stat *"
 "fstatfs","sys/statfs.h","","int","int","FAR struct statfs *"
 "fsync","unistd.h","","int","int"


### PR DESCRIPTION
## Summary

fcntl syscall causes crash in RV64 build. Casting int to uintptr_t causes
32-bit user side pointer to be 0xffffffffc0xxxxxx instead 0x0000..
The parm3 in fcntl syscall API shall be uintptr_t instead of int
`"fcntl","fcntl.h","","int","int","int","...","uintptr_t"`

## Impact

Kernel crash in case of file lock used
```
[CPU1] riscv_exception: EXCEPTION: Load page fault. MCAUSE: 000000000000000d, EPC: 00000000a0012c22, MTVAL: ffffffffc2008e78
[CPU1] riscv_exception: PANIC!!! Exception = 000000000000000d
[CPU1] dump_assert_info: Current Version: NuttX  12.11.0 ee2c4a040a Apr 24 2026 16:25:00 risc-v
[CPU1] dump_assert_info: Assertion failed panic: at file: common/riscv_exception.c:134 task(CPU1): moi_agent_daemon process: moi_agent_daemon 0xc000013e
[CPU1] up_dump_register: EPC: 00000000a0012c22
[CPU1] up_dump_register: A0: 00000000a20af968 A1: ffffffffc2008e78 A2: 00000000a20a2d98 A3: 00000000000000ea
[CPU1] up_dump_register: A4: 0000000000000010 A5: ffffffffffffffe7 A6: 8000000200046022 A7: 0000000000000001
[CPU1] up_dump_register: T0: 0000000000000000 T1: 00000000a001b0b4 T2: 0000000000000000 T3: 000000000000000b
[CPU1] up_dump_register: T4: 0000000000000003 T5: 0000000000000000 T6: 00000000c2008d65
[CPU1] up_dump_register: S0: ffffffffc2008e78 S1: 000000000000000b S2: 0000000000000047 S3: 0000000000000001
[CPU1] up_dump_register: S4: 0000000000000000 S5: 0000000000000002 S6: 00000000a002a7e6 S7: 00000000a2001154
[CPU1] up_dump_register: S8: 00000000a20af968 S9: 0000000000000000 S10: 00000000a20aed38 S11: 0000000000000000
[CPU1] up_dump_register: SP: 00000000a20a2d78 FP: ffffffffc2008e78 TP: 0000000000000000 RA: 00000000a0012ea2
[CPU1] dump_stackinfo: Kernel Stack:
[CPU1] dump_stackinfo:   base: 0xa20a1040
[CPU1] dump_stackinfo:   size: 00008192
[CPU1] dump_stackinfo:     sp: 0xa20a2d78
```
Crash occurs in file_lock_normalize, where A1 contains incorrect address to reference.
```
00000000a0012c20 <file_lock_normalize>:
    a0012c20:   00059703                lh      a4,0(a1)
```
Conversion from int to uintptr_t in PROXY_fcntl.c causes upper word to be 0xffffffff because the 32-bit int 0xc0xxxxxx has bit31 set (negative value).