### PR TITLE
[REVERTME] net/socket: Add msg_copy_from/to_user for CONFIG_BUILD_KERNEL

### DIFF
--- a/net/socket/CMakeLists.txt
+++ b/net/socket/CMakeLists.txt
@@ -44,6 +44,12 @@ set(SRCS
     net_poll.c
     net_fstat.c)
 
+# User-space address environment bounce buffering for msghdr
+
+if(CONFIG_BUILD_KERNEL)
+  list(APPEND SRCS msg_copyusr.c)
+endif()
+
 # Socket options
 
 if(CONFIG_NET_SOCKOPTS)

--- a/net/socket/Make.defs
+++ b/net/socket/Make.defs
@@ -27,6 +27,12 @@ SOCK_CSRCS += listen.c recv.c recvfrom.c send.c sendto.c socket.c
 SOCK_CSRCS += socketpair.c net_close.c recvmsg.c sendmsg.c shutdown.c
 SOCK_CSRCS += net_dup2.c net_sockif.c net_poll.c net_fstat.c
 
+# User-space address environment bounce buffering for msghdr
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+SOCK_CSRCS += msg_copyusr.c
+endif
+
 # Socket options
 
 ifeq ($(CONFIG_NET_SOCKOPTS),y)

--- a/net/socket/msg_copyusr.c
+++ b/net/socket/msg_copyusr.c
@@ -1,0 +1,485 @@
+/****************************************************************************
+ * net/socket/msg_copyusr.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/socket.h>
+
+#include <nuttx/kmalloc.h>
+
+#ifdef CONFIG_MM_IOB
+#include <nuttx/mm/iob.h>
+#endif
+
+#include "socket/socket.h"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct msg_kbuf_s
+{
+  struct msghdr       kmsg;        /* Kernel copy of user msghdr */
+#ifdef CONFIG_MM_IOB
+  FAR struct iob_s   *iob;         /* IOB containing this structure */
+#endif
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: msg_alloc_kbuf
+ *
+ * Description:
+ *   In CONFIG_BUILD_KERNEL + CONFIG_ARCH_ADDRENV builds each user process
+ *   has its own MMU page table.  When a blocking socket call yields, the
+ *   scheduler may switch to a different user process, changing the active
+ *   address environment (SATP on RISC-V, TTBR on ARM).  Network callbacks
+ *   that fire in that context and copy data to/from the original user-space
+ *   iov_base / msg_name / msg_control pointers would access the wrong
+ *   physical memory.
+ *
+ *   This function creates a kernel-owned copy of the relevant msghdr
+ *   fields (iov payload, msg_name, msg_control) so that all internal
+ *   network stack accesses go through kernel virtual addresses, which are
+ *   mapped identically in every address environment.
+ *
+ *   The full iovec array is preserved so protocol code that supports
+ *   scatter / gather I/O can continue to iterate over msg_iovlen entries.
+ *   The helper allocates one kernel-owned backing store for the copied
+ *   msghdr state and payload, using a single IOB when everything fits or
+ *   falling back to a single heap allocation otherwise.
+ *
+ * Input Parameters:
+ *   src - Original user-space msghdr (read-only after this call).
+ *   msg - Out parameter. Set to allocated kernel msghdr on success.
+ *
+ * Returned Value:
+ *   0 on success; negated errno on failure:
+ *   -ENOMEM    Allocation failure.
+ *   -EOVERFLOW Size arithmetic overflow.
+ *   -EFAULT    Invalid iov pointer input.
+ *   -EINVAL    Invalid arguments.
+ *
+ ****************************************************************************/
+
+int msg_alloc_kbuf(FAR const struct msghdr *src,
+                   FAR struct msghdr **msg)
+{
+  FAR struct msg_kbuf_s *kbuf = NULL;
+  FAR uint8_t *data;
+  FAR struct iovec *iov = NULL;
+  size_t cmsg_len;
+  size_t name_len;
+  size_t data_len;
+  size_t iovbytes;
+  size_t iovcount;
+  size_t i;
+
+#ifdef CONFIG_MM_IOB
+  FAR struct iob_s *iob = NULL;
+#endif
+
+  if (src == NULL || msg == NULL)
+    {
+      return -EINVAL;
+    }
+
+  *msg = NULL;
+
+  /* First, calculate size of needed data, and validate all inputs */
+
+  iovcount = src->msg_iovlen;
+
+  if (iovcount > 0 && src->msg_iov == NULL)
+    {
+      return -EFAULT;
+    }
+
+  if (iovcount > SIZE_MAX / sizeof(struct iovec))
+    {
+      return -EOVERFLOW;
+    }
+
+  iovbytes    = iovcount * sizeof(struct iovec);
+  cmsg_len    = src->msg_controllen > 0 && src->msg_control != NULL ?
+                src->msg_controllen : 0;
+  name_len    = src->msg_namelen > 0 && src->msg_name != NULL ?
+                src->msg_namelen : 0;
+
+  data_len = sizeof(struct msg_kbuf_s);
+
+  if (iovbytes > SIZE_MAX - data_len)
+    {
+      return -EOVERFLOW;
+    }
+
+  data_len += iovbytes;
+
+  if (name_len > SIZE_MAX - data_len)
+    {
+      return -EOVERFLOW;
+    }
+
+  data_len += name_len;
+
+  if (cmsg_len > SIZE_MAX - data_len)
+    {
+      return -EOVERFLOW;
+    }
+
+  data_len += cmsg_len;
+
+  for (i = 0; i < iovcount; i++)
+    {
+      if (src->msg_iov[i].iov_len > 0 && src->msg_iov[i].iov_base == NULL)
+        {
+          return -EFAULT;
+        }
+
+      if (src->msg_iov[i].iov_len > SIZE_MAX - data_len)
+        {
+          return -EOVERFLOW;
+        }
+
+      data_len += src->msg_iov[i].iov_len;
+    }
+
+  /* Allocate the needed kernel side memory. */
+
+#ifdef CONFIG_MM_IOB
+  /* Check if everything fits in one IOB, in that case allocate from the IOB
+   * pool instead of kernel heap
+   */
+
+  if (data_len <= CONFIG_IOB_BUFSIZE)
+    {
+      iob = iob_alloc(false);
+      if (iob != NULL)
+        {
+          kbuf = (FAR struct msg_kbuf_s *)iob->io_data;
+        }
+    }
+#endif
+
+  if (kbuf == NULL)
+    {
+      kbuf = (FAR struct msg_kbuf_s *)kmm_malloc(data_len);
+    }
+
+  if (kbuf == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  /* Now we have kernel side buffer at kbuf, clear it */
+
+  memset(kbuf, 0, data_len);
+
+#ifdef CONFIG_MM_IOB
+  if (iob)
+    {
+      /* Store the iob pointer for freeing it later */
+
+      kbuf->iob = iob;
+    }
+#endif
+
+  /* Now, set all fields of the kernel-side msghdr */
+
+  data = (FAR uint8_t *)&kbuf[1];
+
+  if (iovcount > 0)
+    {
+      kbuf->kmsg.msg_iov = (FAR struct iovec *)data;
+      kbuf->kmsg.msg_iovlen = iovcount;
+      iov = kbuf->kmsg.msg_iov;
+      data += iovbytes;
+    }
+
+  /* Compile-time layout checks:
+   * - iov[] must start aligned for pointer-sized accesses.
+   * - msg_control starts at: sizeof(msg_kbuf_s) + iovcount * sizeof(iovec).
+   *   Therefore both component sizes must be CMSG_ALIGN-stable so the sum
+   *   remains naturally aligned for any iovcount.
+   */
+
+  static_assert((sizeof(kbuf[0]) & (sizeof(uintptr_t) - 1)) == 0,
+                "msg_kbuf_s size must be pointer aligned");
+  static_assert((sizeof(struct iovec) & (sizeof(uintptr_t) - 1)) == 0,
+                "iovec size must be pointer aligned");
+  static_assert(CMSG_ALIGN(sizeof(kbuf[0])) == sizeof(kbuf[0]),
+                "msg_kbuf_s size must be CMSG_ALIGN aligned");
+  static_assert(CMSG_ALIGN(sizeof(struct iovec)) == sizeof(struct iovec),
+                "iovec size must be CMSG_ALIGN aligned");
+
+  if (cmsg_len > 0)
+    {
+      kbuf->kmsg.msg_control = data;
+      kbuf->kmsg.msg_controllen = cmsg_len;
+      data += cmsg_len;
+    }
+
+  if (name_len > 0)
+    {
+      kbuf->kmsg.msg_name = data;
+      kbuf->kmsg.msg_namelen = name_len;
+      data += name_len;
+    }
+
+  for (i = 0; i < iovcount; i++)
+    {
+      size_t iov_len = src->msg_iov[i].iov_len;
+
+      iov[i].iov_len = iov_len;
+      iov[i].iov_base = data;
+
+      if (iov_len == 0)
+        {
+          continue;
+        }
+
+      data += iov_len;
+    }
+
+  *msg = &kbuf->kmsg;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: msg_copy_from_user
+ *
+ * Description:
+ *   Copy user-space send data into the kernel bounce buffers allocated by
+ *   msg_alloc_kbuf().  Call this after alloc and before psock_sendmsg.
+ *
+ * Input Parameters:
+ *   src - Original user msghdr whose payload and control data to copy.
+ *   msg - Kernel msghdr state filled by msg_alloc_kbuf().
+ *
+ * Returned Value:
+ *   0 on success; -EFAULT if any iov entry with non-zero length has a
+ *   NULL iov_base pointer.
+ *
+ ****************************************************************************/
+
+int msg_copy_from_user(FAR const struct msghdr *src,
+                       FAR struct msghdr *msg)
+{
+  FAR struct msg_kbuf_s *kbuf = (FAR struct msg_kbuf_s *)msg;
+  size_t i;
+
+  /* Validate and copy iov payload from user to kernel IOB. */
+
+  if (src->msg_iov != NULL && kbuf->kmsg.msg_iov != NULL)
+    {
+      for (i = 0; i < src->msg_iovlen; i++)
+        {
+          if (src->msg_iov[i].iov_len > 0)
+            {
+              if (src->msg_iov[i].iov_base == NULL)
+                {
+                  return -EFAULT;
+                }
+
+              if (kbuf->kmsg.msg_iov[i].iov_base != NULL)
+                {
+                  memcpy(kbuf->kmsg.msg_iov[i].iov_base,
+                         src->msg_iov[i].iov_base,
+                         src->msg_iov[i].iov_len);
+                }
+            }
+        }
+    }
+
+  /* Copy destination address from user to kernel buffer (needed by
+   * sendmsg() on datagram sockets).
+   */
+
+  if (src->msg_namelen > 0 && src->msg_name != NULL &&
+      kbuf->kmsg.msg_name != NULL)
+    {
+      memcpy(kbuf->kmsg.msg_name, src->msg_name, src->msg_namelen);
+    }
+
+  /* Copy ancillary control data from user to kernel IOB. */
+
+  if (src->msg_controllen > 0 && src->msg_control != NULL &&
+      kbuf->kmsg.msg_control != NULL)
+    {
+      memcpy(kbuf->kmsg.msg_control, src->msg_control,
+             src->msg_controllen);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: msg_copy_to_user
+ *
+ * Description:
+ *   Copy received data from the kernel bounce buffers back to the original
+ *   user-space msghdr fields.  Call this after psock_recvmsg() returns
+ *   successfully, while the correct address environment is active.
+ *
+ * Input Parameters:
+ *   dst     - Original user-space msghdr to update.
+ *   ksrc    - Kernel msghdr state filled and used by psock_recvmsg().
+ *   recvlen - Number of payload bytes returned by psock_recvmsg().
+ *
+ * Returned Value:
+ *   recvlen on success; -EFAULT if any iov entry with non-zero length has
+ *   a NULL iov_base pointer.  When recvlen is negative (error from
+ *   psock_recvmsg) it is returned unchanged without touching user buffers.
+ *
+ ****************************************************************************/
+
+ssize_t msg_copy_to_user(FAR struct msghdr *dst,
+                         FAR const struct msghdr *src,
+                         ssize_t recvlen)
+{
+  FAR const struct msg_kbuf_s *ksrc = (FAR const struct msg_kbuf_s *)src;
+  ssize_t origlen = recvlen;
+  size_t ncopy;
+  size_t iovcount;
+  size_t i;
+
+  /* Only copy results back on success; on error the user buffers
+   * must not be touched as they may contain partial or undefined data.
+   */
+
+  if (recvlen < 0)
+    {
+      return recvlen;
+    }
+
+  /* Validate and copy received payload back to the user iov buffer. */
+
+  if (recvlen > 0 && dst->msg_iov != NULL && ksrc->kmsg.msg_iov != NULL)
+    {
+      iovcount = dst->msg_iovlen;
+      if (iovcount > ksrc->kmsg.msg_iovlen)
+        {
+          iovcount = ksrc->kmsg.msg_iovlen;
+        }
+
+      for (i = 0; i < iovcount && recvlen > 0; i++)
+        {
+          ncopy = dst->msg_iov[i].iov_len;
+          if (ncopy > (size_t)recvlen)
+            {
+              ncopy = recvlen;
+            }
+
+          if (ncopy > 0)
+            {
+              if (dst->msg_iov[i].iov_base == NULL)
+                {
+                  return (ssize_t)-EFAULT;
+                }
+
+              memcpy(dst->msg_iov[i].iov_base,
+                     ksrc->kmsg.msg_iov[i].iov_base, ncopy);
+              recvlen -= ncopy;
+            }
+        }
+    }
+
+  /* Copy source address back. */
+
+  if (ksrc->kmsg.msg_name != NULL && dst->msg_name != NULL)
+    {
+      memcpy(dst->msg_name, ksrc->kmsg.msg_name,
+             ksrc->kmsg.msg_namelen);
+    }
+
+  /* Copy ancillary data back.
+   * psock_recvmsg() decrements msg_controllen by the amount consumed via
+   * cmsg_append(); the difference is the number of bytes written.
+   */
+
+  if (ksrc->kmsg.msg_control != NULL && dst->msg_control != NULL)
+    {
+      size_t written = ksrc->kmsg.msg_controllen;
+      if (written > 0)
+        {
+          memcpy(dst->msg_control, ksrc->kmsg.msg_control, written);
+        }
+    }
+
+  /* Propagate output fields. */
+
+  dst->msg_namelen    = ksrc->kmsg.msg_namelen;
+  dst->msg_controllen = ksrc->kmsg.msg_controllen;
+  dst->msg_flags      = ksrc->kmsg.msg_flags;
+
+  return origlen;
+}
+
+/****************************************************************************
+ * Name: msg_free_kbuf
+ *
+ * Description:
+ *   Release all kernel memory allocated by msg_alloc_kbuf().
+ *   Safe to call with partially-initialised state; this function checks
+ *   all pointers for NULL before freeing them.
+ *
+ * Input Parameters:
+ *   kbuf - Kernel msghdr state to release.
+ *
+ ****************************************************************************/
+
+void msg_free_kbuf(FAR struct msghdr *msg)
+{
+  FAR struct msg_kbuf_s *kbuf = (FAR struct msg_kbuf_s *)msg;
+
+  if (kbuf == NULL)
+    {
+      return;
+    }
+
+#ifdef CONFIG_MM_IOB
+  if (kbuf->iob != NULL)
+    {
+      iob_free(kbuf->iob);
+    }
+  else
+#endif
+    {
+      kmm_free(kbuf);
+    }
+}
+
+#endif /* CONFIG_BUILD_KERNEL && CONFIG_ARCH_ADDRENV */

--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -26,12 +26,9 @@
 
 #include <nuttx/config.h>
 
-#include <assert.h>
 #include <errno.h>
-#include <string.h>
 
 #include <nuttx/cancelpt.h>
-#include <nuttx/kmalloc.h>
 #include <nuttx/net/net.h>
 
 #include "socket/socket.h"
@@ -81,21 +78,17 @@ ssize_t psock_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
   struct iovec iov;
   ssize_t ret;
 
-  iov.iov_base = buf;
-  iov.iov_len = len;
-  msg.msg_name = from;
-  msg.msg_namelen = fromlen ? *fromlen : 0;
-  msg.msg_iov = &iov;
-  msg.msg_iovlen = 1;
-  msg.msg_control = NULL;
-  msg.msg_controllen = 0;
-  msg.msg_flags = 0;
+  net_init_iov1_msg(&msg, &iov, buf, len, from,
+                    fromlen != NULL ? *fromlen : 0);
 
   /* And let psock_recvmsg do all of the work */
 
   ret = psock_recvmsg(psock, &msg, flags);
+
   if (ret >= 0 && fromlen != NULL)
-    *fromlen = msg.msg_namelen;
+    {
+      *fromlen = msg.msg_namelen;
+    }
 
   return ret;
 }
@@ -157,39 +150,15 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
   FAR struct socket *psock;
   FAR struct file *filep;
   ssize_t ret;
-#ifdef CONFIG_BUILD_KERNEL
-  struct sockaddr_storage kaddr;
-  FAR struct sockaddr *ufrom;
-  FAR void *kbuf;
-  FAR void *ubuf;
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+  struct iovec iov;
+  struct msghdr msg;
+  FAR struct msghdr *kmsg = NULL;
 #endif
 
   /* recvfrom() is a cancellation point */
 
   enter_cancellation_point();
-
-#ifdef CONFIG_BUILD_KERNEL
-  /* Allocate memory and copy user buffer to kernel */
-
-  kbuf = kmm_malloc(len);
-  if (!kbuf)
-    {
-      /* Out of memory */
-
-      ret = -ENOMEM;
-      goto errout_with_cancelpt;
-    }
-
-  ubuf = buf;
-  buf = kbuf;
-
-  /* Copy the address data to kernel, store the original user pointer */
-
-  if ((ufrom = from) != NULL)
-    {
-      from = (FAR struct sockaddr *)&kaddr;
-    }
-#endif
 
   /* Get the underlying socket structure */
 
@@ -199,23 +168,31 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
 
   if (ret == OK)
     {
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+      net_init_iov1_msg(&msg, &iov, buf, len, from,
+                        fromlen != NULL ? *fromlen : 0);
+
+      ret = msg_alloc_kbuf(&msg, &kmsg);
+
+      if (ret == OK)
+        {
+          ret = psock_recvmsg(psock, kmsg, flags);
+          ret = msg_copy_to_user(&msg, kmsg, ret);
+          if (ret >= 0 && fromlen != NULL)
+            {
+              *fromlen = msg.msg_namelen;
+            }
+        }
+
+      if (kmsg != NULL)
+        {
+          msg_free_kbuf(kmsg);
+        }
+#else
       ret = psock_recvfrom(psock, buf, len, flags, from, fromlen);
+#endif
       file_put(filep);
     }
-
-#ifdef CONFIG_BUILD_KERNEL
-  memcpy(ubuf, buf, len);
-  kmm_free(kbuf);
-
-  /* Copy the address back to user */
-
-  if (ufrom)
-    {
-      memcpy(ufrom, &kaddr, *fromlen);
-    }
-
-errout_with_cancelpt:
-#endif
 
   leave_cancellation_point();
 

--- a/net/socket/recvmsg.c
+++ b/net/socket/recvmsg.c
@@ -178,7 +178,36 @@ ssize_t recvmsg(int sockfd, FAR struct msghdr *msg, int flags)
 
   if (ret == OK)
     {
-      ret = psock_recvmsg(psock, msg, flags);
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+      FAR struct msghdr *umsg = msg;
+
+      /* In kernel build with address environments each user process has its
+       * own MMU page table (SATP on RISC-V, TTBR on ARM).  When this task
+       * blocks waiting for data, the scheduler may switch to a different
+       * user process, changing the active address environment.  The network
+       * callback that eventually copies received data fires in that context
+       * and would write to the wrong physical memory if it used the original
+       * user-space iov_base pointer directly.
+       *
+       * Fix: allocate kernel-side IOB bounce buffers and redirect the msghdr
+       * to them before the shared psock_recvmsg() call below.  After the
+       * call (back in the correct address environment) copy results back.
+       * See net/socket/msg_copyusr.c for the helpers.
+       */
+
+      ret = msg_alloc_kbuf(msg, &msg);
+#endif
+
+      if (ret == OK)
+        {
+          ret = psock_recvmsg(psock, msg, flags);
+
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+          ret = msg_copy_to_user(umsg, msg, ret);
+          msg_free_kbuf(msg);
+#endif
+        }
+
       file_put(filep);
     }
 

--- a/net/socket/sendmsg.c
+++ b/net/socket/sendmsg.c
@@ -157,7 +157,43 @@ ssize_t sendmsg(int sockfd, FAR struct msghdr *msg, int flags)
 
   if (ret == OK)
     {
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+      FAR struct msghdr *umsg = msg;
+
+      /* In kernel build with address environments the TX callback that
+       * calls devif_send() may fire while a different user process is
+       * active (different SATP/TTBR), causing reads from the wrong
+       * physical memory if the original user-space iov_base is used.
+       *
+       * Fix: copy user payload and control data into kernel-owned IOB
+       * bounce buffers and redirect the msghdr to them before the shared
+       * psock_sendmsg() call below so the callback always reads from
+       * kernel addresses regardless of the active address environment.
+       * See net/socket/msg_copyusr.c for the helpers.
+       */
+
+      ret = msg_alloc_kbuf(msg, &msg);
+      if (ret == OK)
+        {
+          ret = msg_copy_from_user(umsg, msg);
+        }
+
+      if (ret == OK)
+        {
+          ret = psock_sendmsg(psock, msg, flags);
+        }
+
+      if (msg != NULL)
+        {
+          msg_free_kbuf(msg);
+        }
+
+#else
+
       ret = psock_sendmsg(psock, msg, flags);
+
+#endif
+
       file_put(filep);
     }
 

--- a/net/socket/sendto.c
+++ b/net/socket/sendto.c
@@ -29,13 +29,10 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <stdint.h>
-#include <string.h>
-#include <assert.h>
 #include <errno.h>
 #include <debug.h>
 
 #include <nuttx/cancelpt.h>
-#include <nuttx/kmalloc.h>
 #include <nuttx/net/net.h>
 
 #include "socket/socket.h"
@@ -119,15 +116,8 @@ ssize_t psock_sendto(FAR struct socket *psock, FAR const void *buf,
       return -EINVAL;
     }
 
-  iov.iov_base = (FAR void *)buf;
-  iov.iov_len = len;
-  msg.msg_name = (FAR struct sockaddr *)to;
-  msg.msg_namelen = tolen;
-  msg.msg_iov = &iov;
-  msg.msg_iovlen = 1;
-  msg.msg_control = NULL;
-  msg.msg_controllen = 0;
-  msg.msg_flags = 0;
+  net_init_iov1_msg(&msg, &iov, (FAR void *)buf, len,
+                    (FAR struct sockaddr *)to, tolen);
 
   /* And let psock_sendmsg do all of the work */
 
@@ -203,38 +193,15 @@ ssize_t sendto(int sockfd, FAR const void *buf, size_t len, int flags,
   FAR struct socket *psock;
   FAR struct file *filep;
   ssize_t ret;
-#ifdef CONFIG_BUILD_KERNEL
-  struct sockaddr_storage kaddr;
-  FAR void *kbuf;
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+  struct iovec iov;
+  struct msghdr msg;
+  FAR struct msghdr *kmsg = NULL;
 #endif
 
   /* sendto() is a cancellation point */
 
   enter_cancellation_point();
-
-#ifdef CONFIG_BUILD_KERNEL
-  /* Allocate memory and copy user buffer to kernel */
-
-  kbuf = kmm_malloc(len);
-  if (!kbuf)
-    {
-      /* Out of memory */
-
-      ret = -ENOMEM;
-      goto errout_with_cancelpt;
-    }
-
-  memcpy(kbuf, buf, len);
-  buf = kbuf;
-
-  /* Copy the address data to kernel */
-
-  if (to)
-    {
-      memcpy(&kaddr, to, tolen);
-      to = (FAR const struct sockaddr *)&kaddr;
-    }
-#endif
 
   /* Get the underlying socket structure */
 
@@ -244,15 +211,39 @@ ssize_t sendto(int sockfd, FAR const void *buf, size_t len, int flags,
 
   if (ret == OK)
     {
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+      if (tolen != 0 && to == NULL)
+        {
+          ret = -EINVAL;
+        }
+
+      if (ret == OK)
+        {
+          net_init_iov1_msg(&msg, &iov, (FAR void *)buf, len,
+                            (FAR struct sockaddr *)to, tolen);
+
+          ret = msg_alloc_kbuf(&msg, &kmsg);
+        }
+
+      if (ret == OK)
+        {
+          ret = msg_copy_from_user(&msg, kmsg);
+        }
+
+      if (ret == OK)
+        {
+          ret = psock_sendmsg(psock, kmsg, flags);
+        }
+
+      if (kmsg != NULL)
+        {
+          msg_free_kbuf(kmsg);
+        }
+#else
       ret = psock_sendto(psock, buf, len, flags, to, tolen);
+#endif
       file_put(filep);
     }
-
-#ifdef CONFIG_BUILD_KERNEL
-  kmm_free(kbuf);
-
-errout_with_cancelpt:
-#endif
 
   leave_cancellation_point();
 

--- a/net/socket/socket.h
+++ b/net/socket/socket.h
@@ -34,6 +34,8 @@
 #include <stdint.h>
 #include <time.h>
 
+#include <sys/socket.h>
+
 #include <nuttx/fs/fs.h>
 #include <nuttx/clock.h>
 #include <nuttx/net/net.h>
@@ -159,6 +161,17 @@ extern "C"
 
 FAR const struct sock_intf_s *
 net_sockif(sa_family_t family, int type, int protocol);
+
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
+int msg_alloc_kbuf(FAR const struct msghdr *src,
+                   FAR struct msghdr **msg);
+int msg_copy_from_user(FAR const struct msghdr *src,
+                       FAR struct msghdr *msg);
+ssize_t msg_copy_to_user(FAR struct msghdr *dst,
+                         FAR const struct msghdr *src,
+                         ssize_t recvlen);
+void msg_free_kbuf(FAR struct msghdr *msg);
+#endif /* CONFIG_BUILD_KERNEL && CONFIG_ARCH_ADDRENV */
 
 /****************************************************************************
  * Name: net_timeo

--- a/net/socket/socket.h
+++ b/net/socket/socket.h
@@ -162,6 +162,32 @@ extern "C"
 FAR const struct sock_intf_s *
 net_sockif(sa_family_t family, int type, int protocol);
 
+/****************************************************************************
+ * Name: net_init_iov1_msg
+ *
+ * Description:
+ *   Initialize an msghdr + single iovec view used by sendto/recvfrom style
+ *   wrappers.
+ *
+ ****************************************************************************/
+
+static inline void net_init_iov1_msg(FAR struct msghdr *msg,
+                                     FAR struct iovec *iov,
+                                     FAR void *buf, size_t len,
+                                     FAR struct sockaddr *name,
+                                     socklen_t namelen)
+{
+  iov->iov_base      = buf;
+  iov->iov_len       = len;
+  msg->msg_name      = name;
+  msg->msg_namelen   = namelen;
+  msg->msg_iov       = iov;
+  msg->msg_iovlen    = 1;
+  msg->msg_control   = NULL;
+  msg->msg_controllen = 0;
+  msg->msg_flags     = 0;
+}
+
 #if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_ADDRENV)
 int msg_alloc_kbuf(FAR const struct msghdr *src,
                    FAR struct msghdr **msg);


### PR DESCRIPTION
Hai earlier reported "https://jira.tii.ae/browse/SSRCDP-11725", he found corrupted can frames coming from NuttX network stack.

The issue appeared at some point, when updating NuttX baseline to a newer one, but it was never quite understood.

The issue seems to be profound and serious; in kernel builds, the network stack sometimes uses user-side buffer pointers in copying data, in recvmsg /sendmsg - not just for can, but for all blocking socket transfers.

This adds copying to/from kerenel memory when doing sendmsg/recvmsg to avoid corrupting messages or other process' address environment, when the actual device drivers do copy while the calling process is blocked.

This patch allocates one IOB for storing the metadata and the payload. If the payload doesn't fit in the IOB, the payload is allocated from the kernel heap.

In other words, to optimize number of heap allocations, one can increase the IOB size so that all the packets fit in one IOB.

