### PR TITLE
arch/arm64/Imx9: support pmic reset from kernel panic/assert

### DIFF
--- a/arch/arm64/src/imx9/Make.defs
+++ b/arch/arm64/src/imx9/Make.defs
@@ -120,7 +120,7 @@ ifeq ($(CONFIG_IMX9_FLEXCAN), y)
   CHIP_CSRCS += imx9_flexcan.c
 endif
 
-ifneq ($(CONFI_IMX9_HAVE_ATF_FIRMWARE), y)
+ifneq ($(CONFIG_IMX9_HAVE_ATF_FIRMWARE), y)
   CHIP_CSRCS += imx9_reset.c
 endif
 

--- a/arch/arm64/src/imx9/imx9_flexspi_nor.c
+++ b/arch/arm64/src/imx9/imx9_flexspi_nor.c
@@ -420,6 +420,9 @@ struct imx9_flexspi_nor_dev_s
  * Private Functions Prototypes
  ****************************************************************************/
 
+static int imx9_flexspi_nor_reset_memory_private(
+                          struct imx9_flexspi_nor_dev_s *priv);
+
 /* MTD driver methods */
 
 static int imx9_flexspi_nor_erase(struct mtd_dev_s *dev,
@@ -994,16 +997,7 @@ static int imx9_flexspi_nor_ioctl(struct mtd_dev_s *dev,
         {
           /* Reset the memory */
 
-          imx9_flexspi_nor_write_cmd(priv, RESET_ENABLE);
-          up_udelay(1);
-          ret = imx9_flexspi_nor_write_cmd(priv, RESET_MEMORY);
-          if (ret)
-            {
-              ferr("reset memory failed\n");
-            }
-
-          imx9_flexspi_nor_wait_bus_busy(priv);
-          FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+          ret = imx9_flexspi_nor_reset_memory_private(priv);
         }
         break;
 
@@ -1015,9 +1009,44 @@ static int imx9_flexspi_nor_ioctl(struct mtd_dev_s *dev,
   return ret;
 }
 
+static int imx9_flexspi_nor_reset_memory_private(
+                          struct imx9_flexspi_nor_dev_s *priv)
+{
+  int ret;
+
+  ret = imx9_flexspi_nor_write_cmd(priv, RESET_ENABLE);
+  if (ret)
+    {
+      ferr("reset memory failed\n");
+      return ret;
+    }
+
+  up_udelay(1);
+
+  ret = imx9_flexspi_nor_write_cmd(priv, RESET_MEMORY);
+  if (ret)
+    {
+      ferr("reset memory failed\n");
+      return ret;
+    }
+
+  imx9_flexspi_nor_wait_bus_busy(priv);
+  FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+
+  return ret;
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+int imx9_flexspi_nor_reset_memory(struct mtd_dev_s *dev)
+{
+  struct imx9_flexspi_nor_dev_s *priv =
+                  (struct imx9_flexspi_nor_dev_s *)dev;
+
+  return imx9_flexspi_nor_reset_memory_private(priv);
+}
 
 /****************************************************************************
  * Name: imx9_flexspi_nor_initialize

--- a/arch/arm64/src/imx9/imx9_flexspi_nor.c
+++ b/arch/arm64/src/imx9/imx9_flexspi_nor.c
@@ -420,6 +420,9 @@ struct imx9_flexspi_nor_dev_s
  * Private Functions Prototypes
  ****************************************************************************/
 
+static int imx9_flexspi_nor_reset_memory_private(
+  struct imx9_flexspi_nor_dev_s *priv);
+
 /* MTD driver methods */
 
 static int imx9_flexspi_nor_erase(struct mtd_dev_s *dev,
@@ -994,16 +997,7 @@ static int imx9_flexspi_nor_ioctl(struct mtd_dev_s *dev,
         {
           /* Reset the memory */
 
-          imx9_flexspi_nor_write_cmd(priv, RESET_ENABLE);
-          up_udelay(1);
-          ret = imx9_flexspi_nor_write_cmd(priv, RESET_MEMORY);
-          if (ret)
-            {
-              ferr("reset memory failed\n");
-            }
-
-          imx9_flexspi_nor_wait_bus_busy(priv);
-          FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+          ret = imx9_flexspi_nor_reset_memory_private(priv);
         }
         break;
 
@@ -1015,9 +1009,44 @@ static int imx9_flexspi_nor_ioctl(struct mtd_dev_s *dev,
   return ret;
 }
 
+static int imx9_flexspi_nor_reset_memory_private(
+                struct imx9_flexspi_nor_dev_s *priv)
+{
+  int ret;
+
+  ret = imx9_flexspi_nor_write_cmd(priv, RESET_ENABLE);
+  if (ret)
+    {
+      ferr("reset memory failed\n");
+      return ret;
+    }
+
+  up_udelay(1);
+
+  ret = imx9_flexspi_nor_write_cmd(priv, RESET_MEMORY);
+  if (ret)
+    {
+      ferr("reset memory failed\n");
+      return ret;
+    }
+
+  imx9_flexspi_nor_wait_bus_busy(priv);
+  FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+
+  return ret;
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+int imx9_flexspi_nor_reset_memory(struct mtd_dev_s *dev)
+{
+  struct imx9_flexspi_nor_dev_s *priv =
+                  (struct imx9_flexspi_nor_dev_s *)dev;
+
+  return imx9_flexspi_nor_reset_memory_private(priv);
+}
 
 /****************************************************************************
  * Name: imx9_flexspi_nor_initialize

--- a/arch/arm64/src/imx9/imx9_flexspi_nor.h
+++ b/arch/arm64/src/imx9/imx9_flexspi_nor.h
@@ -75,6 +75,22 @@ extern "C"
 
 struct mtd_dev_s *imx9_flexspi_nor_initialize(int intf);
 
+/****************************************************************************
+ * Name: imx9_flexspi_nor_reset_memory
+ *
+ * Description:
+ *   Reset NOR FLASH memory on FlexSPI interface
+ *
+ * Input Parameters:
+ *   Pointer to an mtd device
+ *
+ * Returned Value:
+ *   errno
+ *
+ ****************************************************************************/
+
+int imx9_flexspi_nor_reset_memory(struct mtd_dev_s *dev);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/arch/arm64/src/imx9/imx9_flexspi_nor.h
+++ b/arch/arm64/src/imx9/imx9_flexspi_nor.h
@@ -75,6 +75,22 @@ extern "C"
 
 struct mtd_dev_s *imx9_flexspi_nor_initialize(int intf);
 
+/****************************************************************************
+ * Name: imx9_flexspi_nor_reset_memory
+ *
+ * Description:
+ *   Reset NOR FLASH memory on FlexSPI interface
+ *
+ * Input Parameters:
+ *   Pointer to an mtd device
+ *
+ * Returned Value:
+ *   Zero on success, negated errno on failure
+ *
+ ****************************************************************************/
+
+int imx9_flexspi_nor_reset_memory(struct mtd_dev_s *dev);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -232,6 +232,7 @@ struct imx9_lpi2c_priv_s
   DMACH_HANDLE txdma;                               /* tx DMA handle */
   uint16_t     cmnds[CONFIG_IMX9_LPI2C_DMA_MAXMSG]; /* Commands */
 #endif
+  bool polling_mode;           /* interrupt or polling based transfer */
 };
 
 /****************************************************************************
@@ -365,7 +366,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c1_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -409,7 +415,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c2_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -453,7 +464,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c3_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -497,7 +513,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c4_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -541,7 +562,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c5_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -585,7 +611,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c6_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -629,7 +660,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c7_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -673,7 +709,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c8_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -769,72 +810,66 @@ static uint32_t imx9_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_I2C_POLLED
-static inline int
-imx9_lpi2c_sem_waitdone(struct imx9_lpi2c_priv_s *priv)
-{
-  int ret;
-
-#ifdef CONFIG_IMX9_LPI2C_DYNTIMEO
-  ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
-                                       imx9_lpi2c_toticks(priv->msgc,
-                                                          priv->msgv));
-#else
-  ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
-                                       CONFIG_IMX9_LPI2C_TIMEOTICKS);
-#endif
-
-  /* Set the interrupt state back to IDLE */
-
-  priv->intstate = INTSTATE_IDLE;
-
-  return ret;
-}
-#else
 static inline int
 imx9_lpi2c_sem_waitdone(struct imx9_lpi2c_priv_s *priv)
 {
   clock_t timeout;
   clock_t start;
   clock_t elapsed;
-  int ret;
+  int ret = OK;
 
-  /* Get the timeout value */
+  if (priv->polling_mode)
+    {
+      /* Get the timeout value */
 
 #ifdef CONFIG_IMX9_LPI2C_DYNTIMEO
-  timeout = imx9_lpi2c_toticks(priv->msgc, priv->msgv);
+      timeout = imx9_lpi2c_toticks(priv->msgc, priv->msgv);
 #else
-  timeout = CONFIG_IMX9_LPI2C_TIMEOTICKS;
+      timeout = CONFIG_IMX9_LPI2C_TIMEOTICKS;
 #endif
-  start = clock_systime_ticks();
+      start = clock_systime_ticks();
 
-  do
+      do
+        {
+          /* Calculate the elapsed time */
+
+          elapsed = clock_systime_ticks() - start;
+
+          /* Poll by simply calling the timer interrupt handler until it
+           * reports that it is done.
+           */
+
+          imx9_lpi2c_isr_process(priv);
+        }
+
+      /* Loop until the transfer is complete. */
+
+      while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
+
+      i2cinfo("intstate: %d elapsed: %ld threshold: %ld status: %08x\n",
+              priv->intstate, (long)elapsed, (long)timeout, priv->status);
+
+      /* Set the interrupt state back to IDLE */
+
+      ret = priv->intstate == INTSTATE_DONE ? OK : -ETIMEDOUT;
+    }
+  else
     {
-      /* Calculate the elapsed time */
-
-      elapsed = clock_systime_ticks() - start;
-
-      /* Poll by simply calling the timer interrupt handler until it
-       * reports that it is done.
-       */
-
-      imx9_lpi2c_isr_process(priv);
+#ifndef CONFIG_I2C_POLLED
+#ifdef CONFIG_IMX9_LPI2C_DYNTIMEO
+      ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
+                                       imx9_lpi2c_toticks(priv->msgc,
+                                                          priv->msgv));
+#else
+      ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
+                                       CONFIG_IMX9_LPI2C_TIMEOTICKS);
+#endif
+#endif
     }
 
-  /* Loop until the transfer is complete. */
-
-  while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
-
-  i2cinfo("intstate: %d elapsed: %ld threshold: %ld status: %08x\n",
-          priv->intstate, (long)elapsed, (long)timeout, priv->status);
-
-  /* Set the interrupt state back to IDLE */
-
-  ret = priv->intstate == INTSTATE_DONE ? OK : -ETIMEDOUT;
   priv->intstate = INTSTATE_IDLE;
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: imx9_rxdma_callback
@@ -1345,21 +1380,23 @@ static int imx9_lpi2c_stop_transfer(struct imx9_lpi2c_priv_s *priv)
   priv->dcnt = 0;
 
 #ifndef CONFIG_I2C_POLLED
-
-  /* Disable interrupts */
-
-  imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MIER_OFFSET,
-                       LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
-                       LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
-                       LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
-
-  /* Inform the thread that transfer is complete
-   * and wake it up
-   */
-
-  if (priv->intstate == INTSTATE_WAITING)
+  if (!priv->polling_mode)
     {
-      nxsem_post(&priv->sem_isr);
+      /* Disable interrupts */
+
+      imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MIER_OFFSET,
+                          LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
+                          LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
+                          LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
+
+      /* Inform the thread that transfer is complete
+       * and wake it up
+       */
+
+      if (priv->intstate == INTSTATE_WAITING)
+        {
+          nxsem_post(&priv->sem_isr);
+        }
     }
 #endif
 
@@ -1691,8 +1728,12 @@ static int imx9_lpi2c_init(struct imx9_lpi2c_priv_s *priv)
   /* Attach ISRs */
 
 #ifndef CONFIG_I2C_POLLED
-  irq_attach(priv->config->irq, imx9_lpi2c_isr, priv);
-  up_enable_irq(priv->config->irq);
+  if (!priv->polling_mode)
+    {
+      irq_attach(priv->config->irq, imx9_lpi2c_isr, priv);
+      up_enable_irq(priv->config->irq);
+    }
+
 #endif
 
   /* Enable I2C */
@@ -1723,8 +1764,12 @@ static int imx9_lpi2c_deinit(struct imx9_lpi2c_priv_s *priv)
   /* Disable and detach interrupts */
 
 #ifndef CONFIG_I2C_POLLED
-  up_disable_irq(priv->config->irq);
-  irq_detach(priv->config->irq);
+  if (!priv->polling_mode)
+    {
+      up_disable_irq(priv->config->irq);
+      irq_detach(priv->config->irq);
+    }
+
 #endif
 
   /* Disable clocking */
@@ -1978,7 +2023,7 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
                                struct i2c_msg_s *msgs, int count)
 {
   struct imx9_lpi2c_priv_s *priv = (struct imx9_lpi2c_priv_s *)dev;
-  int ret;
+  int ret = OK;
 #ifdef CONFIG_IMX9_LPI2C_DMA
   int m;
 #endif
@@ -2073,7 +2118,12 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
        * imx9_lpi2c_stop_transfer above
        */
 
-      nxsem_reset(&priv->sem_isr, 0);
+#ifndef CONFIG_I2C_POLLED
+      if (!priv->polling_mode)
+        {
+          nxsem_reset(&priv->sem_isr, 0);
+        }
+#endif
     }
 
   /* Check for error status conditions */
@@ -2132,6 +2182,7 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
 #endif
 
   nxmutex_unlock(&priv->lock);
+
   return ret;
 }
 
@@ -2211,23 +2262,22 @@ static int imx9_lpi2c_reset(struct i2c_master_s *dev)
   /* Release the port for reuse by other clients */
 
   nxmutex_unlock(&priv->lock);
+
   return ret;
 }
 #endif /* CONFIG_I2C_RESET */
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: imx9_i2cbus_initialize
+ * Name: imx9_i2cbus_initialize_mode
  *
  * Description:
  *   Initialize one I2C bus
- *
+ *   Select for normal init or init from interrupts disabled context
  ****************************************************************************/
 
-struct i2c_master_s *imx9_i2cbus_initialize(int port)
+static struct i2c_master_s *imx9_i2cbus_initialize_mode(int port,
+                                                        bool polling_mode,
+                                                        bool force)
 {
   struct imx9_lpi2c_priv_s * priv = NULL;
   irqstate_t flags;
@@ -2286,21 +2336,41 @@ struct i2c_master_s *imx9_i2cbus_initialize(int port)
 
   flags = enter_critical_section();
 
-  if ((volatile int)priv->refs++ == 0)
+  if ((volatile int)priv->refs++ == 0 || force)
     {
+      priv->polling_mode = polling_mode;
+
+      /* In forced polling mode, reset the mutex to avoid deadlock in
+       * case called from kernel panic
+       */
+
+      if (force && nxmutex_is_locked(&priv->lock))
+        {
+          i2cinfo("force reset mutex\n");
+          nxmutex_reset(&priv->lock);
+        }
+
       imx9_lpi2c_init(priv);
 
 #ifdef CONFIG_IMX9_LPI2C_DMA
-      if (priv->config->dma_txreqsrc != 0)
+      if (!priv->polling_mode)
         {
-          priv->txdma = imx9_dmach_alloc(priv->config->dma_txreqsrc, 0);
-          DEBUGASSERT(priv->txdma != NULL);
-        }
+          if (priv->config->dma_txreqsrc != 0)
+            {
+              priv->txdma = imx9_dmach_alloc(priv->config->dma_txreqsrc, 0);
+              DEBUGASSERT(priv->txdma != NULL);
+            }
 
-      if (priv->config->dma_rxreqsrc != 0)
+          if (priv->config->dma_rxreqsrc != 0)
+            {
+              priv->rxdma = imx9_dmach_alloc(priv->config->dma_rxreqsrc, 0);
+              DEBUGASSERT(priv->rxdma != NULL);
+            }
+        }
+      else
         {
-          priv->rxdma = imx9_dmach_alloc(priv->config->dma_rxreqsrc, 0);
-          DEBUGASSERT(priv->rxdma != NULL);
+          priv->txdma = NULL;
+          priv->rxdma = NULL;
         }
 #endif
     }
@@ -2308,6 +2378,42 @@ struct i2c_master_s *imx9_i2cbus_initialize(int port)
   leave_critical_section(flags);
 
   return (struct i2c_master_s *)priv;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx9_i2cbus_initialize
+ *
+ * Description:
+ *   Initialize one I2C bus for interrupt based mode
+ *
+ ****************************************************************************/
+
+struct i2c_master_s *imx9_i2cbus_initialize(int port)
+{
+  return imx9_i2cbus_initialize_mode(port,
+#ifdef CONFIG_I2C_POLLED
+    true,
+#else
+    false,
+#endif
+    false);
+}
+
+/****************************************************************************
+ * Name: imx9_i2cbus_initialize_forced_polling
+ *
+ * Description:
+ *   Force to re-initialize one I2C bus for polling mode
+ *
+ ****************************************************************************/
+
+struct i2c_master_s *imx9_i2cbus_initialize_forced_polling(int port)
+{
+  return imx9_i2cbus_initialize_mode(port, true, true);
 }
 
 /****************************************************************************
@@ -2345,18 +2451,21 @@ int imx9_i2cbus_uninitialize(struct i2c_master_s *dev)
   /* Disable power and other HW resource (GPIO's) */
 
 #ifdef CONFIG_IMX9_LPI2C_DMA
-  if (priv->rxdma != NULL)
+  if (!priv->polling_mode)
     {
-      imx9_dmach_stop(priv->rxdma);
-      imx9_dmach_free(priv->rxdma);
-      priv->rxdma = NULL;
-    }
+      if (priv->rxdma != NULL)
+        {
+          imx9_dmach_stop(priv->rxdma);
+          imx9_dmach_free(priv->rxdma);
+          priv->rxdma = NULL;
+        }
 
-  if (priv->txdma != NULL)
-    {
-      imx9_dmach_stop(priv->txdma);
-      imx9_dmach_free(priv->txdma);
-      priv->txdma = NULL;
+      if (priv->txdma != NULL)
+        {
+          imx9_dmach_stop(priv->txdma);
+          imx9_dmach_free(priv->txdma);
+          priv->txdma = NULL;
+        }
     }
 #endif
 

--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -37,6 +37,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/init.h>
 #include <nuttx/irq.h>
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
@@ -232,6 +233,7 @@ struct imx9_lpi2c_priv_s
   DMACH_HANDLE txdma;                               /* tx DMA handle */
   uint16_t     cmnds[CONFIG_IMX9_LPI2C_DMA_MAXMSG]; /* Commands */
 #endif
+  bool polling_mode;           /* interrupt or polling based transfer */
 };
 
 /****************************************************************************
@@ -409,7 +411,12 @@ static struct imx9_lpi2c_priv_s imx9_lpi2c2_priv =
   .ptr           = NULL,
   .dcnt          = 0,
   .flags         = 0,
-  .status        = 0
+  .status        = 0,
+#ifdef CONFIG_I2C_POLLED
+  .polling_mode  = true,
+#else
+  .polling_mode  = false,
+#endif
 };
 #endif
 
@@ -769,28 +776,6 @@ static uint32_t imx9_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_I2C_POLLED
-static inline int
-imx9_lpi2c_sem_waitdone(struct imx9_lpi2c_priv_s *priv)
-{
-  int ret;
-
-#ifdef CONFIG_IMX9_LPI2C_DYNTIMEO
-  ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
-                                       imx9_lpi2c_toticks(priv->msgc,
-                                                          priv->msgv));
-#else
-  ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
-                                       CONFIG_IMX9_LPI2C_TIMEOTICKS);
-#endif
-
-  /* Set the interrupt state back to IDLE */
-
-  priv->intstate = INTSTATE_IDLE;
-
-  return ret;
-}
-#else
 static inline int
 imx9_lpi2c_sem_waitdone(struct imx9_lpi2c_priv_s *priv)
 {
@@ -799,42 +784,56 @@ imx9_lpi2c_sem_waitdone(struct imx9_lpi2c_priv_s *priv)
   clock_t elapsed;
   int ret;
 
-  /* Get the timeout value */
+  if (priv->polling_mode)
+    {
+      /* Get the timeout value */
 
 #ifdef CONFIG_IMX9_LPI2C_DYNTIMEO
-  timeout = imx9_lpi2c_toticks(priv->msgc, priv->msgv);
+     timeout = imx9_lpi2c_toticks(priv->msgc, priv->msgv);
 #else
-  timeout = CONFIG_IMX9_LPI2C_TIMEOTICKS;
+      timeout = CONFIG_IMX9_LPI2C_TIMEOTICKS;
 #endif
-  start = clock_systime_ticks();
+      start = clock_systime_ticks();
 
-  do
+      do
+        {
+          /* Calculate the elapsed time */
+
+          elapsed = clock_systime_ticks() - start;
+
+          /* Poll by simply calling the timer interrupt handler until it
+           * reports that it is done.
+           */
+
+          imx9_lpi2c_isr_process(priv);
+        }
+
+      /* Loop until the transfer is complete. */
+
+      while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
+
+      i2cinfo("intstate: %d elapsed: %ld threshold: %ld status: %08x\n",
+              priv->intstate, (long)elapsed, (long)timeout, priv->status);
+
+      /* Set the interrupt state back to IDLE */
+
+      ret = priv->intstate == INTSTATE_DONE ? OK : -ETIMEDOUT;
+    }
+  else
     {
-      /* Calculate the elapsed time */
-
-      elapsed = clock_systime_ticks() - start;
-
-      /* Poll by simply calling the timer interrupt handler until it
-       * reports that it is done.
-       */
-
-      imx9_lpi2c_isr_process(priv);
+#ifdef CONFIG_IMX9_LPI2C_DYNTIMEO
+      ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
+                                       imx9_lpi2c_toticks(priv->msgc,
+                                                          priv->msgv));
+#else
+      ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
+                                       CONFIG_IMX9_LPI2C_TIMEOTICKS);
+#endif
     }
 
-  /* Loop until the transfer is complete. */
-
-  while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
-
-  i2cinfo("intstate: %d elapsed: %ld threshold: %ld status: %08x\n",
-          priv->intstate, (long)elapsed, (long)timeout, priv->status);
-
-  /* Set the interrupt state back to IDLE */
-
-  ret = priv->intstate == INTSTATE_DONE ? OK : -ETIMEDOUT;
   priv->intstate = INTSTATE_IDLE;
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: imx9_rxdma_callback
@@ -1346,20 +1345,23 @@ static int imx9_lpi2c_stop_transfer(struct imx9_lpi2c_priv_s *priv)
 
 #ifndef CONFIG_I2C_POLLED
 
-  /* Disable interrupts */
-
-  imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MIER_OFFSET,
-                       LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
-                       LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
-                       LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
-
-  /* Inform the thread that transfer is complete
-   * and wake it up
-   */
-
-  if (priv->intstate == INTSTATE_WAITING)
+  if (!priv->polling_mode)
     {
-      nxsem_post(&priv->sem_isr);
+      /* Disable interrupts */
+
+      imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MIER_OFFSET,
+                          LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
+                          LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
+                          LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
+
+      /* Inform the thread that transfer is complete
+       * and wake it up
+       */
+
+      if (priv->intstate == INTSTATE_WAITING)
+        {
+          nxsem_post(&priv->sem_isr);
+        }
     }
 #endif
 
@@ -1690,10 +1692,11 @@ static int imx9_lpi2c_init(struct imx9_lpi2c_priv_s *priv)
 
   /* Attach ISRs */
 
-#ifndef CONFIG_I2C_POLLED
-  irq_attach(priv->config->irq, imx9_lpi2c_isr, priv);
-  up_enable_irq(priv->config->irq);
-#endif
+  if (!priv->polling_mode)
+    {
+      irq_attach(priv->config->irq, imx9_lpi2c_isr, priv);
+      up_enable_irq(priv->config->irq);
+    }
 
   /* Enable I2C */
 
@@ -1722,10 +1725,11 @@ static int imx9_lpi2c_deinit(struct imx9_lpi2c_priv_s *priv)
 
   /* Disable and detach interrupts */
 
-#ifndef CONFIG_I2C_POLLED
-  up_disable_irq(priv->config->irq);
-  irq_detach(priv->config->irq);
-#endif
+  if (!priv->polling_mode)
+    {
+      up_disable_irq(priv->config->irq);
+      irq_detach(priv->config->irq);
+    }
 
   /* Disable clocking */
 
@@ -1978,19 +1982,25 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
                                struct i2c_msg_s *msgs, int count)
 {
   struct imx9_lpi2c_priv_s *priv = (struct imx9_lpi2c_priv_s *)dev;
-  int ret;
+  int ret = OK;
 #ifdef CONFIG_IMX9_LPI2C_DMA
   int m;
 #endif
 
   DEBUGASSERT(count > 0);
 
-  /* Ensure that address or flags don't change meanwhile */
+  /* Ensure that address or flags don't change meanwhile.
+   * Check if the i2c is requested from kernel panic
+   * handler (for pmic reset).
+   */
 
-  ret = nxmutex_lock(&priv->lock);
-  if (ret < 0)
+  if (!priv->polling_mode)
     {
-      return ret;
+      ret = nxmutex_lock(&priv->lock);
+      if (ret < 0)
+        {
+          return ret;
+        }
     }
 
   /* Clear any pending error interrupts */
@@ -2073,7 +2083,10 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
        * imx9_lpi2c_stop_transfer above
        */
 
-      nxsem_reset(&priv->sem_isr, 0);
+      if (!priv->polling_mode)
+        {
+          nxsem_reset(&priv->sem_isr, 0);
+        }
     }
 
   /* Check for error status conditions */
@@ -2131,8 +2144,104 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
     }
 #endif
 
-  nxmutex_unlock(&priv->lock);
+  if (!priv->polling_mode)
+    {
+      nxmutex_unlock(&priv->lock);
+    }
+
   return ret;
+}
+
+/****************************************************************************
+ * Name: imx9_lpi2c_recover_bus
+ *
+ * Description:
+ *   Panic-safe I2C bus recovery for when the bus is stuck
+ *   This function can be called from interrupts disabled context
+ *   Uses polling-based bus recovery without delays or locks
+ *
+ * Input Parameters:
+ *   priv - I2C device private data
+ *
+ * Returned Value:
+ *   OK if bus recovered successfully
+ *   -EIO if bus recovery failed
+ *
+ ****************************************************************************/
+
+static int imx9_lpi2c_recover_bus(struct i2c_master_s *dev)
+{
+  uint32_t status;
+  int count;
+
+  struct imx9_lpi2c_priv_s *priv = (struct imx9_lpi2c_priv_s *)dev;
+
+  if (priv == NULL)
+    {
+      return -EINVAL;
+    }
+
+  /* Check if bus is busy */
+
+  status = imx9_lpi2c_getreg(priv, IMX9_LPI2C_MSR_OFFSET);
+
+  if ((status & LPI2C_MSR_BBF) == 0)
+    {
+      /* Bus is free, no recovery needed */
+
+      return OK;
+    }
+
+  /* Bus is stuck, attempt recovery */
+
+  /* Set relaxed mode - allows clocking the bus even when busy */
+
+  imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MCFGR0_OFFSET,
+                       0, LPI2C_MCFG0_RELAX);
+
+  /* Clock the bus by sending START and STOP conditions (max 10 attempts) */
+
+  for (count = 0; count < 10; count++)
+    {
+      /* Check status and clear any error flags */
+
+      status = imx9_lpi2c_getreg(priv, IMX9_LPI2C_MSR_OFFSET);
+
+      if ((status & LPI2C_MSR_ERROR_MASK) != 0)
+        {
+          imx9_lpi2c_putreg(priv, IMX9_LPI2C_MSR_OFFSET,
+                            status & LPI2C_MSR_ERROR_MASK);
+        }
+
+      /* Send START and STOP to clock the bus */
+
+      imx9_lpi2c_putreg(priv, IMX9_LPI2C_MTDR_OFFSET,
+                        LPI2C_MTDR_CMD_START | LPI2C_MTDR_DATA(0));
+      imx9_lpi2c_putreg(priv, IMX9_LPI2C_MTDR_OFFSET,
+                        LPI2C_MTDR_CMD_STOP);
+
+      /* Poll to check if bus is now free (without delays) */
+
+      status = imx9_lpi2c_getreg(priv, IMX9_LPI2C_MSR_OFFSET);
+
+      if ((status & LPI2C_MSR_BBF) == 0)
+        {
+          /* Bus recovered successfully */
+
+          break;
+        }
+    }
+
+  /* Exit relaxed mode */
+
+  imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MCFGR0_OFFSET,
+                       LPI2C_MCFG0_RELAX, 0);
+
+  /* Check final status */
+
+  status = imx9_lpi2c_getreg(priv, IMX9_LPI2C_MSR_OFFSET);
+
+  return ((status & LPI2C_MSR_BBF) == 0) ? OK : -EIO;
 }
 
 /****************************************************************************
@@ -2216,18 +2325,16 @@ static int imx9_lpi2c_reset(struct i2c_master_s *dev)
 #endif /* CONFIG_I2C_RESET */
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: imx9_i2cbus_initialize
+ * Name: imx9_i2cbus_initialize_mode
  *
  * Description:
  *   Initialize one I2C bus
- *
+ *   Select for normal init or init from interrupts disabled context
  ****************************************************************************/
 
-struct i2c_master_s *imx9_i2cbus_initialize(int port)
+static struct i2c_master_s *imx9_i2cbus_initialize_mode(int port,
+                                                        bool polling_mode,
+                                                        bool force)
 {
   struct imx9_lpi2c_priv_s * priv = NULL;
   irqstate_t flags;
@@ -2286,21 +2393,30 @@ struct i2c_master_s *imx9_i2cbus_initialize(int port)
 
   flags = enter_critical_section();
 
-  if ((volatile int)priv->refs++ == 0)
+  if ((volatile int)priv->refs++ == 0 || force)
     {
+      priv->polling_mode = polling_mode;
       imx9_lpi2c_init(priv);
 
 #ifdef CONFIG_IMX9_LPI2C_DMA
-      if (priv->config->dma_txreqsrc != 0)
+      if (!priv->polling_mode)
         {
-          priv->txdma = imx9_dmach_alloc(priv->config->dma_txreqsrc, 0);
-          DEBUGASSERT(priv->txdma != NULL);
-        }
+          if (priv->config->dma_txreqsrc != 0)
+            {
+              priv->txdma = imx9_dmach_alloc(priv->config->dma_txreqsrc, 0);
+              DEBUGASSERT(priv->txdma != NULL);
+            }
 
-      if (priv->config->dma_rxreqsrc != 0)
+          if (priv->config->dma_rxreqsrc != 0)
+            {
+              priv->rxdma = imx9_dmach_alloc(priv->config->dma_rxreqsrc, 0);
+              DEBUGASSERT(priv->rxdma != NULL);
+            }
+        }
+      else
         {
-          priv->rxdma = imx9_dmach_alloc(priv->config->dma_rxreqsrc, 0);
-          DEBUGASSERT(priv->rxdma != NULL);
+          priv->txdma = NULL;
+          priv->rxdma = NULL;
         }
 #endif
     }
@@ -2308,6 +2424,42 @@ struct i2c_master_s *imx9_i2cbus_initialize(int port)
   leave_critical_section(flags);
 
   return (struct i2c_master_s *)priv;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx9_i2cbus_initialize
+ *
+ * Description:
+ *   Initialize one I2C bus for interrupt based mode
+ *
+ ****************************************************************************/
+
+struct i2c_master_s *imx9_i2cbus_initialize(int port)
+{
+  return imx9_i2cbus_initialize_mode(port,
+#ifdef CONFIG_I2C_POLLED
+    true,
+#else
+    false,
+#endif
+    false);
+}
+
+/****************************************************************************
+ * Name: imx9_i2cbus_initialize_forced_polling
+ *
+ * Description:
+ *   Force to override initialization of one I2C bus for polling mode
+ *
+ ****************************************************************************/
+
+struct i2c_master_s *imx9_i2cbus_initialize_forced_polling(int port)
+{
+  return imx9_i2cbus_initialize_mode(port, true, true);
 }
 
 /****************************************************************************
@@ -2345,24 +2497,48 @@ int imx9_i2cbus_uninitialize(struct i2c_master_s *dev)
   /* Disable power and other HW resource (GPIO's) */
 
 #ifdef CONFIG_IMX9_LPI2C_DMA
-  if (priv->rxdma != NULL)
+  if (!priv->polling_mode)
     {
-      imx9_dmach_stop(priv->rxdma);
-      imx9_dmach_free(priv->rxdma);
-      priv->rxdma = NULL;
-    }
+      if (priv->rxdma != NULL)
+        {
+          imx9_dmach_stop(priv->rxdma);
+          imx9_dmach_free(priv->rxdma);
+          priv->rxdma = NULL;
+        }
 
-  if (priv->txdma != NULL)
-    {
-      imx9_dmach_stop(priv->txdma);
-      imx9_dmach_free(priv->txdma);
-      priv->txdma = NULL;
+      if (priv->txdma != NULL)
+        {
+          imx9_dmach_stop(priv->txdma);
+          imx9_dmach_free(priv->txdma);
+          priv->txdma = NULL;
+        }
     }
 #endif
 
   imx9_lpi2c_deinit(priv);
 
   return OK;
+}
+
+/****************************************************************************
+ * Name: imx9_i2cbus_recover
+ *
+ * Description:
+ *   Attempt to recover a stuck I2C bus.
+ *
+ * Input Parameters:
+ *   devt - Pointer to I2C bus device
+ *
+ * Returned Value:
+ *   OK if bus recovered successfully or was already free
+ *   -EIO if recovery failed
+ *   -EINVAL if invalid port
+ *
+ ****************************************************************************/
+
+int imx9_i2cbus_recover(struct i2c_master_s *dev)
+{
+  return imx9_lpi2c_recover_bus(dev);
 }
 
 #endif /* CONFIG_IMX9_LPI2C */

--- a/arch/arm64/src/imx9/imx9_lpi2c.h
+++ b/arch/arm64/src/imx9/imx9_lpi2c.h
@@ -27,6 +27,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <stdbool.h>
 #include <nuttx/config.h>
 #include <nuttx/i2c/i2c_master.h>
 
@@ -69,5 +70,24 @@ struct i2c_master_s *imx9_i2cbus_initialize(int port);
  ****************************************************************************/
 
 int imx9_i2cbus_uninitialize(struct i2c_master_s *dev);
+
+/****************************************************************************
+ * Name: imx9_i2cbus_recover
+ *
+ * Description:
+ *   Attempt to recover a stuck I2C bus.
+ *   Uses polling-based bus recovery without locks or delays.
+ *
+ * Input Parameters:
+ *   Device structure as returned by the imx9_i2cbus_initialize()
+ *
+ * Returned Value:
+ *   OK if bus recovered successfully or was already free
+ *   -EIO if recovery failed
+ *   -EINVAL if invalid port
+ *
+ ****************************************************************************/
+
+int imx9_i2cbus_recover(struct i2c_master_s *dev);
 
 #endif /* __ARCH_ARM64_SRC_IMX9_IMX9_LPI2C_H */

--- a/arch/arm64/src/imx9/imx9_pmic.c
+++ b/arch/arm64/src/imx9/imx9_pmic.c
@@ -51,9 +51,17 @@
 #define REG_RESET_CTRL          0x08
 #define COLD_RESET              0x64
 #define WARM_RESET              0x35
+#define PMIC_RESET_WAIT_US      1000
+#define PMIC_TRY_COUNT             3
 
 /****************************************************************************
- * Public Functions
+ * Private Function Prototypes
+ ****************************************************************************/
+
+struct i2c_master_s *imx9_i2cbus_initialize_forced_polling(int port);
+
+/****************************************************************************
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
@@ -69,18 +77,20 @@ static int imx9_pmic_reg_read(uint8_t reg, uint8_t *value)
   struct i2c_master_s *i2c;
   struct i2c_msg_s msgs[2];
   uint8_t reg_addr = reg;
-  int ret;
+  int trycount;
+  int ret = 0;
 
   if (!value)
     {
-      _err("Invalid value parameter\n");
+      i2cerr("Invalid value parameter\n");
       return -EINVAL;
     }
 
   i2c = imx9_i2cbus_initialize(CONFIG_IMX9_PMIC_I2C);
+
   if (i2c == NULL)
     {
-      _err("Failed to initialize I2C bus\n");
+      i2cerr("Failed to initialize I2C bus\n");
       return -ENODEV;
     }
 
@@ -96,10 +106,19 @@ static int imx9_pmic_reg_read(uint8_t reg, uint8_t *value)
   msgs[1].buffer    = value;
   msgs[1].length    = 1;
 
-  ret = I2C_TRANSFER(i2c, msgs, 2);
-  if (ret < 0)
+  trycount = PMIC_TRY_COUNT;
+  while (trycount--)
     {
-      _err("I2C transfer failed: %d\n", ret);
+      ret = I2C_TRANSFER(i2c, msgs, 2);
+      if (ret == 0)
+        {
+          break;
+        }
+
+      i2cerr("I2C transfer failed: %d\n", ret);
+#ifdef CONFIG_I2C_RESET
+      I2C_RESET(i2c);
+#endif
     }
 
   imx9_i2cbus_uninitialize(i2c);
@@ -108,7 +127,7 @@ static int imx9_pmic_reg_read(uint8_t reg, uint8_t *value)
 }
 
 /****************************************************************************
- * Name: imx9_pmic_reg_read
+ * Name: imx9_pmic_reg_write
  *
  * Description:
  *   Write 8-bit register value to pmic
@@ -120,12 +139,13 @@ static int imx9_pmic_reg_write(uint8_t reg, uint8_t val)
   struct i2c_master_s *i2c;
   struct i2c_msg_s msg;
   uint8_t buffer[2];
-  int ret;
+  int trycount;
+  int ret = 0;
 
   i2c = imx9_i2cbus_initialize(CONFIG_IMX9_PMIC_I2C);
   if (i2c == NULL)
     {
-      _err("Failed to initialize I2C bus\n");
+      i2cerr("Failed to initialize I2C bus\n");
       return -ENODEV;
     }
 
@@ -138,10 +158,19 @@ static int imx9_pmic_reg_write(uint8_t reg, uint8_t val)
   msg.buffer    = buffer;
   msg.length    = 2;
 
-  ret = I2C_TRANSFER(i2c, &msg, 1);
-  if (ret < 0)
+  trycount = PMIC_TRY_COUNT;
+  while (trycount--)
     {
-      _err("I2C transfer failed: %d\n", ret);
+      ret = I2C_TRANSFER(i2c, &msg, 1);
+      if (ret == 0)
+        {
+          break;
+        }
+
+      i2cerr("I2C transfer failed: %d\n", ret);
+#ifdef CONFIG_I2C_RESET
+      I2C_RESET(i2c);
+#endif
     }
 
   imx9_i2cbus_uninitialize(i2c);
@@ -150,10 +179,17 @@ static int imx9_pmic_reg_write(uint8_t reg, uint8_t val)
 }
 
 /****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: imx9_pmic_reset
  *
  * Description:
  *   Reset SoC via pmic
+ *
+ * Returned Value:
+ *   Zero on success, negated errno on failure.
  *
  ****************************************************************************/
 
@@ -168,6 +204,9 @@ int imx9_pmic_reset(void)
  * Description:
  *   Read reset reason from pmic
  *
+ * Returned Value:
+ *   Zero on success, negated errno on failure.
+ *
  ****************************************************************************/
 
 int imx9_pmic_get_reset_reason(uint8_t *value)
@@ -180,6 +219,9 @@ int imx9_pmic_get_reset_reason(uint8_t *value)
  *
  * Description:
  *  Read reset control register value
+ *
+ * Returned Value:
+ *   Zero on success, negated errno on failure.
  *
  ****************************************************************************/
 
@@ -198,11 +240,72 @@ int imx9_pmic_get_reset_ctrl(uint8_t *value)
  *   Register value
  *
  * Returned Value:
- *   None
+ *   Zero on success, negated errno on failure.
  *
  ****************************************************************************/
 
 int imx9_pmic_set_reset_ctrl(uint8_t val)
 {
   return imx9_pmic_reg_write(REG_RESET_CTRL, val);
+}
+
+/****************************************************************************
+ * Name: imx9_pmic_forced_reset_with_ctrl
+ *
+ * Description:
+ *  Force the polling mode transfer, set reset control register and
+ *  reset SoC via pmic.
+ *  This can be called from kernel panic handler.
+ *
+ * Input Parameters:
+ *   Reset Control register value
+ *
+ * Returned Value:
+ *   Function does not return
+ *
+ ****************************************************************************/
+
+noreturn_function void imx9_pmic_forced_reset_with_ctrl(uint8_t val)
+{
+  int ret = 1;
+  struct i2c_master_s *i2c;
+
+  enter_critical_section();
+
+  /* Forced reset, loop until success */
+
+  while (ret)
+    {
+      /* Busy-wait here to make sure previous i2c transfer has
+       * been ended before the forced pmic reset is performed.
+       */
+
+      up_udelay(PMIC_RESET_WAIT_US);
+
+      i2c = imx9_i2cbus_initialize_forced_polling(
+                                                  CONFIG_IMX9_PMIC_I2C);
+      if (i2c == NULL)
+        {
+          /* Forced initialization failed, try again */
+
+          continue;
+        }
+
+      ret = imx9_pmic_reg_write(REG_RESET_CTRL, val);
+      if (ret < 0)
+        {
+          imx9_i2cbus_uninitialize(i2c);
+          continue;
+        }
+
+      ret = imx9_pmic_reg_write(REG_SW_RST, COLD_RESET);
+      if (ret < 0)
+        {
+          imx9_i2cbus_uninitialize(i2c);
+        }
+    }
+
+  imx9_i2cbus_uninitialize(i2c);
+
+  while (1);
 }

--- a/arch/arm64/src/imx9/imx9_pmic.h
+++ b/arch/arm64/src/imx9/imx9_pmic.h
@@ -114,6 +114,22 @@ int imx9_pmic_get_reset_ctrl(uint8_t *value);
 
 int imx9_pmic_set_reset_ctrl(uint8_t val);
 
+/****************************************************************************
+ * Name: imx9_pmic_forced_reset_with_ctrl
+ *
+ * Description:
+ *  Force set reset control register and perform pmic reset.
+ *
+ * Input Parameters:
+ *   Register value
+ *
+ * Returned Value:
+ *   Function does not return
+ *
+ ****************************************************************************/
+
+void imx9_pmic_forced_reset_with_ctrl(uint8_t val) noreturn_function;
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary

imx9 pmic_reset requires interrupt based i2c transfer to perform system reset.
That is not possible after kernel panic (_assert) while interrupts are already
disabled and other SMP cores are halted. This patch implements support
for pmic_reset to be called from interrupt context. The lpi2c provides interface
to use polling based transfer.
Also, some boards requires to reset flexspi_nor memory before system reset to
avoid entering into NXP USB flashing mode, so the flexspi_nor implements
support for performing memory reset from interrupt disabled context.e

## Impact

Allows imx9 based boards to enable CONFIG_BOARD_RESET_ON_ASSERT to
perform pmic system reset after kernel panic.

## Testing

Verified with costom imx9 board using test code to generate kernel panic.
PMIC reset is generated after kernel panic occurs.


