### PR TITLE
arch/risc-v/src/mpfs/mpfs_gpio.c: Fix muxed gpio irq handling

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_gpio.c
+++ b/arch/risc-v/src/mpfs/mpfs_gpio.c
@@ -114,8 +114,8 @@ static int mpfs_gpio_isr(int irq, void *context, void *arg)
   uint8_t irq_n = irq - MPFS_IRQ_GPIO02_BIT0;
   int ret = OK;
 
-  uint8_t mss_bank = irq_n < GPIO_BANK1_NUM_PINS ? 0 : 1;
-  uint8_t pin = mss_bank == 1 ? irq_n - GPIO_BANK0_NUM_PINS : irq_n;
+  uint8_t mss_bank = irq_n < GPIO_BANK0_NUM_PINS ? 0 : 1;
+  uint8_t mss_pin = mss_bank == 1 ? irq_n - GPIO_BANK0_NUM_PINS : irq_n;
   uint32_t event_reg;
   struct gpio_callback_s *cb;
 
@@ -123,20 +123,25 @@ static int mpfs_gpio_isr(int irq, void *context, void *arg)
 
   /* bank 0 and bank 1 pins */
 
-  cb = &g_mss_gpio_callbacks[irq_n];
-  event_reg = getreg32(g_gpio_base[mss_bank] + MPFS_GPIO_INTR_OFFSET);
-
-  /* if the callback is registered and there is an interrupt on the mss_pin */
-
-  if (cb->callback != NULL && (event_reg & (1 << pin)) != 0)
+  if (irq_n < (GPIO_BANK0_NUM_PINS + GPIO_BANK1_NUM_PINS))
     {
-      /* clear the pending interrupt */
+      cb = &g_mss_gpio_callbacks[irq_n];
+      event_reg = getreg32(g_gpio_base[mss_bank] + MPFS_GPIO_INTR_OFFSET);
 
-      mpfs_gpio_irq_clear(mss_bank, pin);
+      /* if the callback is registered and there is an interrupt on the
+       * mss_pin
+       */
 
-      /* dispatch the interrupt to the handler */
+      if (cb->callback != NULL && (event_reg & (1 << mss_pin)) != 0)
+        {
+          /* clear the pending interrupt */
 
-      ret = cb->callback(irq, context, cb->arg);
+          mpfs_gpio_irq_clear(mss_bank, mss_pin);
+
+          /* dispatch the interrupt to the handler */
+
+          ret = cb->callback(irq, context, cb->arg);
+        }
     }
 
   /* handle the muxed gpio bank2 interrupt */
@@ -145,11 +150,11 @@ static int mpfs_gpio_isr(int irq, void *context, void *arg)
     {
       cb = &g_fab_gpio_callbacks[irq_n];
       event_reg = getreg32(g_gpio_base[2] + MPFS_GPIO_INTR_OFFSET);
-      if (cb->callback != NULL && (event_reg & (1 << pin)) != 0)
+      if (cb->callback != NULL && (event_reg & (1 << irq_n)) != 0)
         {
           /* clear the pending interrupt */
 
-          mpfs_gpio_irq_clear(2, pin);
+          mpfs_gpio_irq_clear(2, irq_n);
 
           /* dispatch the interrupt to the handler */
 


### PR DESCRIPTION
This patch fixes 2 issues in mpfs_gpio_irq:
1) The bank number for 0/1 is calculated wrong, causing bank1 0-9 not working

2) For bank2, it is incorrectly using "pin" variable which is only for
   mss pins; this caused bank2 pins 24-31 not working.

Fix the both issues, and add a sanity check for proper irq number also for bank0/1. Also change variable pin to mss_pin for clarity.

I can send this to upstream nuttx as well after testing.