### PR TITLE
Fix fabric io dispatch logic and bank2 pin mapping

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_gpio.c
+++ b/arch/risc-v/src/mpfs/mpfs_gpio.c
@@ -111,54 +111,50 @@ static void mpfs_gpio_irq_clear(int bank, int pin)
 
 static int mpfs_gpio_isr(int irq, void *context, void *arg)
 {
-  uint8_t irq_n = irq - MPFS_IRQ_GPIO02_BIT0;
   int ret = OK;
 
-  uint8_t mss_bank = irq_n < GPIO_BANK1_NUM_PINS ? 0 : 1;
-  uint8_t pin = mss_bank == 1 ? irq_n - GPIO_BANK0_NUM_PINS : irq_n;
-  uint32_t event_reg;
-  struct gpio_callback_s *cb;
+  /* Calculate the GPIO IRQ number offset */
+  uint8_t irq_n = irq - MPFS_IRQ_GPIO02_BIT0;
 
-  /* if mss gpio interrupt is enabled and there is an event */
-
-  /* bank 0 and bank 1 pins */
-
-  cb = &g_mss_gpio_callbacks[irq_n];
-  event_reg = getreg32(g_gpio_base[mss_bank] + MPFS_GPIO_INTR_OFFSET);
-
-  /* if the callback is registered and there is an interrupt on the mss_pin */
-
-  if (cb->callback != NULL && (event_reg & (1 << pin)) != 0)
+  /* ---------- Handle MSS GPIO Bank 0 and Bank 1 ---------- */
+  if (irq_n < GPIO_BANK0_NUM_PINS + GPIO_BANK1_NUM_PINS)
     {
-      /* clear the pending interrupt */
+      uint8_t mss_bank = irq_n < GPIO_BANK0_NUM_PINS ? 0 : 1;
+      uint8_t pin = mss_bank == 1 ? irq_n - GPIO_BANK0_NUM_PINS : irq_n;
 
-      mpfs_gpio_irq_clear(mss_bank, pin);
+      uint32_t event_reg = getreg32(g_gpio_base[mss_bank] + MPFS_GPIO_INTR_OFFSET);
+      struct gpio_callback_s *cb = &g_mss_gpio_callbacks[irq_n];
 
-      /* dispatch the interrupt to the handler */
-
-      ret = cb->callback(irq, context, cb->arg);
-    }
-
-  /* handle the muxed gpio bank2 interrupt */
-
-  if (irq_n < GPIO_BANK2_NUM_PINS)
-    {
-      cb = &g_fab_gpio_callbacks[irq_n];
-      event_reg = getreg32(g_gpio_base[2] + MPFS_GPIO_INTR_OFFSET);
       if (cb->callback != NULL && (event_reg & (1 << pin)) != 0)
         {
-          /* clear the pending interrupt */
+          /* Clear pending interrupt */
+          mpfs_gpio_irq_clear(mss_bank, pin);
 
-          mpfs_gpio_irq_clear(2, pin);
+          /* Dispatch to the registered callback */
+          ret = cb->callback(irq, context, cb->arg);
+        }
+    }
 
-          /* dispatch the interrupt to the handler */
+  /* ---------- Handle Fabric GPIO Bank 2 ---------- */
+  if (irq_n < GPIO_BANK2_NUM_PINS)
+    {
+      uint8_t pin2 = irq_n;  // Bank 2 has flat mapping
+      uint32_t event_reg = getreg32(g_gpio_base[2] + MPFS_GPIO_INTR_OFFSET);
+      struct gpio_callback_s *cb = &g_fab_gpio_callbacks[irq_n];
 
+      if (cb->callback != NULL && (event_reg & (1 << pin2)) != 0)
+        {
+          /* Clear pending interrupt */
+          mpfs_gpio_irq_clear(2, pin2);
+
+          /* Dispatch to the registered callback */
           ret = cb->callback(irq, context, cb->arg);
         }
     }
 
   return ret;
 }
+
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
Summary

Fix the GPIO interrupt dispatcher issue on the MPFS platform. The change ensures that interrupts are correctly dispatched to the registered GPIO handler.

Impact

This change affects only MPFS GPIO interrupt handling. No API, configuration, or compatibility changes are introduced.

Testing

Tested on the MPFS platform using the GPIO pins where the issue previously occurred. Verified that interrupts are now correctly received and dispatched to the registered handlers.

